### PR TITLE
Remove unnecessary raise

### DIFF
--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -76,7 +76,7 @@ class GeminiHarvester(SpatialHarvester):
                 self._save_object_error('Error importing Gemini document.', harvest_object, 'Import')
             else:
                 self._save_object_error('Error importing Gemini document: %s' % str(e), harvest_object, 'Import')
-            raise
+
             if debug_exception_mode:
                 raise
 


### PR DESCRIPTION
It looks like this was added accidentally as part of https://github.com/ckan/ckanext-spatial/commit/50df9130cf20ef739e845f3639e2b2004c0d98e9 but then not removed. I can see that another raise was removed in https://github.com/ckan/ckanext-spatial/commit/ba2656287ddac532df224a503928efa8e7cb7a7e but got missed from this file.

This is causing the fetch process to die when it hits this line as nothing handles the exception.

[Trello Card](https://trello.com/c/oSTgv8l5/807-find-out-whether-rolling-back-harvesters-has-improved-the-situation)