### PR TITLE
Return 'unchanged' if no change detected during gemini import

### DIFF
--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -68,8 +68,7 @@ class GeminiHarvester(SpatialHarvester):
             self._save_object_error('Empty content for object %s' % harvest_object.id,harvest_object,'Import')
             return False
         try:
-            self.import_gemini_object(harvest_object)
-            return True
+            return self.import_gemini_object(harvest_object)
         except Exception, e:
             log.error('Exception during import: %s' % text_traceback())
             if not str(e).strip():
@@ -103,6 +102,10 @@ class GeminiHarvester(SpatialHarvester):
         # may raise Exception for errors
         package_dict = self.write_package_from_gemini_string(unicode_gemini_string, harvest_object)
 
+        if package_dict:
+            return True
+        else:
+            return 'unchanged'
 
     def write_package_from_gemini_string(self, content, harvest_object):
         '''Create or update a Package based on some content that has


### PR DESCRIPTION
This PR addresses a bug where unchanged harvest objects are being reported as being deleted.

Currently the Gemini Harvester returns `True` for the import stage, which is used by the `Queue` in core CKAN to assign the report status for each harvested object. `True` is returned even if `import_gemini_object` detects that there is no change between the previous and current harvested object.

`CKANEXT-harvest` uses this value to set the `report_status` for the harvest object, and is currently setting this to `deleted` for unchanged objects. This leads to misleading statistics in the frontend. 
This PR https://github.com/alphagov/ckanext-harvest/pull/4 adds additional information for more accurate frontend statistics reporting.


This commit checks the result of `import_gemini_object` and, if it has detected no change, will now return the string `unchanged`. 