### PR TITLE
Add gemini 2 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ syntax: glob
 *~
 dist
 build
+
+# local files
+.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,14 @@ Full documentation, including installation instructions, can be found at:
 
 http://docs.ckan.org/projects/ckanext-spatial
 
+Gemini 2.3 schema
+-----------------
+
+In order to try out a Gemini 2.3 file with the validator add this to the harvest source config -
+
+.. code-block:: json
+
+    {"validator_profiles": ["iso19139eden", "constraints-1.4", "gemini2-3"]}
 
 Community
 ---------
@@ -54,4 +62,3 @@ http://www.fsf.org/licensing/licenses/agpl-3.0.html
 .. _pycsw: http://pycsw.org
 .. _GeoJSON: http://geojson.org
 .. _ckanext-geoview: https://github.com/ckan/ckanext-geoview
-

--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -730,7 +730,6 @@ class SpatialHarvester(HarvesterBase):
                     if custom_validator not in all_validators:
                         self._validator.add_validator(custom_validator)
 
-
         return self._validator
 
     def _get_user_name(self):

--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -99,6 +99,10 @@ class GeminiHarvester(SpatialHarvester):
             log.error('Errors found for object with GUID %s:' % self.obj.guid)
             self._save_object_error(out,self.obj,'Import')
 
+        if datetime.today() > datetime(2019, 12, 1) and hasattr(self, '_validator'):
+            if any(schema in ['gemini2', 'gemini2-1.3'] for schema in self._validator.profiles):
+                self._save_object_error('gemini2/gemini2-1.3 will be deprecated, please use gemin2-3', self.obj, 'Validation')
+
         unicode_gemini_string = etree.tostring(xml, encoding=unicode, pretty_print=True)
 
         # may raise Exception for errors

--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -61,6 +61,8 @@ class GeminiHarvester(SpatialHarvester):
             log.error('No harvest object received')
             return False
 
+        self._set_source_config(harvest_object.source.config)
+
         # Save a reference
         self.obj = harvest_object
 

--- a/ckanext/spatial/tests/test_harvest.py
+++ b/ckanext/spatial/tests/test_harvest.py
@@ -3,6 +3,7 @@ from datetime import datetime, date
 import lxml
 import json
 from uuid import uuid4
+from freezegun import freeze_time
 from nose.plugins.skip import SkipTest
 from nose.tools import assert_equal, assert_in, assert_raises
 
@@ -1101,6 +1102,7 @@ class TestValidation(HarvestFixtureBase):
         errors = self.get_validation_errors('03_Dataset_Invalid_GEMINI_Missing_Keyword.xml')
         assert len(errors) > 0
         assert_in('Descriptive keywords are mandatory', errors)
+        assert_in('gemini2/gemini 2-1.3 will be deprecated, please use gemin2-3', errors)
 
     def test_04_dataset_valid(self):
         errors = self.get_validation_errors('04_Dataset_Valid.xml')
@@ -1159,7 +1161,7 @@ class TestValidation(HarvestFixtureBase):
             'source_type': u'gemini-single'
         }
 
-        errors = self.get_validation_errors('InvalidGemini2_3.xml', source_fixture=source_fixture, config=config)
+        errors = self.get_validation_errors('BGSsv-examplea1.xml', source_fixture=source_fixture, config=config)
         assert not errors
 
     def test_15_gemini2_3_dataset_invalid(self):
@@ -1174,3 +1176,21 @@ class TestValidation(HarvestFixtureBase):
         errors = self.get_validation_errors('InvalidGemini2_3.xml', source_fixture=source_fixture, config=config)
         assert errors
         assert_in('Error Message: "MI-4b (Abstract): Abstract is too short. GEMINI 2.3 requires', errors)
+
+    @freeze_time("2019-12-10T00:00:00")
+    def test_16_deprecation_message(self):
+        errors = self.get_validation_errors('04_Dataset_Valid.xml')
+        assert len(errors) > 0
+        assert_in('gemini2/gemini2-1.3 will be deprecated, please use gemin2-3', errors)
+
+    @freeze_time("2019-12-10T00:00:00")
+    def test_17_no_deprecation_message_for_gemini_2_3(self):
+        config = '{"validator_profiles": ["iso19139eden", "constraints-1.4", "gemini2-3"]}'
+        source_fixture = {
+            'title': 'Test Source',
+            'name': 'test-source',
+            'url': u'http://127.0.0.1:8999/gemini2.3/validation/BGSsv-examplea1.xml',
+            'source_type': u'gemini-single'
+        }
+        errors = self.get_validation_errors('BGSsv-examplea1.xml', source_fixture=source_fixture, config=config)
+        assert not errors

--- a/ckanext/spatial/tests/test_harvest.py
+++ b/ckanext/spatial/tests/test_harvest.py
@@ -1145,3 +1145,28 @@ class TestValidation(HarvestFixtureBase):
         errors = self.get_validation_errors('13_Dataset_Invalid_Element_srv.xml')
         assert len(errors) > 0
         assert_in('Element \'{http://www.isotc211.org/2005/srv}SV_ServiceIdentification\': This element is not expected.', errors)
+
+    def test_14_gemini2_3_dataset_valid(self):
+        SpatialHarvester._validator = Validators(profiles=['iso19139eden', 'constraints', 'gemini2-3'])
+        source_fixture = {
+            'title': 'Test Source',
+            'name': 'test-source',
+            'url': u'http://127.0.0.1:8999/gemini2.3/validation/BGSsv-examplea1.xml',
+            'source_type': u'gemini-single'
+        }
+
+        errors = self.get_validation_errors('InvalidGemini2_3.xml', source_fixture=source_fixture)
+        assert not errors
+
+    def test_15_gemini2_3_dataset_invalid(self):
+        SpatialHarvester._validator = Validators(profiles=['iso19139eden', 'constraints', 'gemini2-3'])
+        source_fixture = {
+            'title': 'Test Source',
+            'name': 'test-source',
+            'url': u'http://127.0.0.1:8999/gemini2.3/validation/InvalidGemini2_3.xml',
+            'source_type': u'gemini-single'
+        }
+
+        errors = self.get_validation_errors('InvalidGemini2_3.xml', source_fixture=source_fixture)
+        assert errors
+        assert_in('Error Message: "MI-4b (Abstract): Abstract is too short. GEMINI 2.3 requires', errors)

--- a/ckanext/spatial/tests/test_harvest.py
+++ b/ckanext/spatial/tests/test_harvest.py
@@ -1052,7 +1052,7 @@ class TestValidation(HarvestFixtureBase):
         SpatialHarvester._validator = Validators(profiles=['iso19139eden', 'constraints', 'gemini2'])
         HarvestFixtureBase.setup_class()
 
-    def get_validation_errors(self, validation_test_filename, source_fixture=None):
+    def get_validation_errors(self, validation_test_filename, source_fixture=None, config=None):
         # Create source
         if not source_fixture:
             source_fixture = {
@@ -1065,6 +1065,10 @@ class TestValidation(HarvestFixtureBase):
         source, job = self._create_source_and_job(source_fixture)
 
         harvester = GeminiDocHarvester()
+        if config:
+            if hasattr(SpatialHarvester, '_validator'):
+                del SpatialHarvester._validator
+            job.source.config = config
 
         # Gather stage for GeminiDocHarvester includes some validation
         object_ids = harvester.gather_stage(job)
@@ -1147,7 +1151,7 @@ class TestValidation(HarvestFixtureBase):
         assert_in('Element \'{http://www.isotc211.org/2005/srv}SV_ServiceIdentification\': This element is not expected.', errors)
 
     def test_14_gemini2_3_dataset_valid(self):
-        SpatialHarvester._validator = Validators(profiles=['iso19139eden', 'constraints', 'gemini2-3'])
+        config = '{"validator_profiles": ["iso19139eden", "constraints-1.4", "gemini2-3"]}'
         source_fixture = {
             'title': 'Test Source',
             'name': 'test-source',
@@ -1155,11 +1159,11 @@ class TestValidation(HarvestFixtureBase):
             'source_type': u'gemini-single'
         }
 
-        errors = self.get_validation_errors('InvalidGemini2_3.xml', source_fixture=source_fixture)
+        errors = self.get_validation_errors('InvalidGemini2_3.xml', source_fixture=source_fixture, config=config)
         assert not errors
 
     def test_15_gemini2_3_dataset_invalid(self):
-        SpatialHarvester._validator = Validators(profiles=['iso19139eden', 'constraints', 'gemini2-3'])
+        config = '{"validator_profiles": ["iso19139eden", "constraints-1.4", "gemini2-3"]}'
         source_fixture = {
             'title': 'Test Source',
             'name': 'test-source',
@@ -1167,6 +1171,6 @@ class TestValidation(HarvestFixtureBase):
             'source_type': u'gemini-single'
         }
 
-        errors = self.get_validation_errors('InvalidGemini2_3.xml', source_fixture=source_fixture)
+        errors = self.get_validation_errors('InvalidGemini2_3.xml', source_fixture=source_fixture, config=config)
         assert errors
         assert_in('Error Message: "MI-4b (Abstract): Abstract is too short. GEMINI 2.3 requires', errors)

--- a/ckanext/spatial/tests/test_validation.py
+++ b/ckanext/spatial/tests/test_validation.py
@@ -15,12 +15,12 @@ class TestValidation:
     def get_validation_errors(self, validator, validation_test_filename):
         validation_test_filepath = self._get_file_path(validation_test_filename)
         xml = etree.parse(validation_test_filepath)
-        is_valid, errors = validator.is_valid(xml)
+        _, errors = validator.is_valid(xml)
 
-        return ';'.join([e[0] for e in errors])
+        return errors, ';'.join([e[0] for e in errors])
 
     def test_iso19139_failure(self):
-        errors = self.get_validation_errors(validation.ISO19139Schema,
+        _, errors = self.get_validation_errors(validation.ISO19139Schema,
                                             'iso19139/dataset-invalid.xml')
 
         assert len(errors) > 0
@@ -28,7 +28,7 @@ class TestValidation:
         assert_in('{http://www.isotc211.org/2005/gmd}nosuchelement\': This element is not expected.', errors)
 
     def test_iso19139_pass(self):
-        errors = self.get_validation_errors(validation.ISO19139Schema,
+        _, errors = self.get_validation_errors(validation.ISO19139Schema,
                                             'iso19139/dataset.xml')
         assert_equal(errors, '')
 
@@ -37,89 +37,108 @@ class TestValidation:
     # test_harvest
 
     def test_01_dataset_fail_iso19139_schema(self):
-        errors = self.get_validation_errors(validation.ISO19139EdenSchema,
+        _, errors = self.get_validation_errors(validation.ISO19139EdenSchema,
                                             'gemini2.1/validation/01_Dataset_Invalid_XSD_No_Such_Element.xml')
         assert len(errors) > 0
         assert_in('(gmx.xsd)', errors)
         assert_in('\'{http://www.isotc211.org/2005/gmd}nosuchelement\': This element is not expected.', errors)
 
     def test_02_dataset_fail_constraints_schematron(self):
-        errors = self.get_validation_errors(validation.ConstraintsSchematron14,
+        _, errors = self.get_validation_errors(validation.ConstraintsSchematron14,
            'gemini2.1/validation/02_Dataset_Invalid_19139_Missing_Data_Format.xml')
         assert len(errors) > 0
         assert_in('MD_Distribution / MD_Format: count(distributionFormat + distributorFormat) > 0', errors)
 
     def test_03_dataset_fail_gemini_schematron(self):
-        errors = self.get_validation_errors(validation.Gemini2Schematron,
+        _, errors = self.get_validation_errors(validation.Gemini2Schematron,
             'gemini2.1/validation/03_Dataset_Invalid_GEMINI_Missing_Keyword.xml')
         assert len(errors) > 0
         assert_in('Descriptive keywords are mandatory', errors)
 
-    def assert_passes_all_gemini2_1_validation(self, xml_filepath):
-        errs = self.get_validation_errors(validation.ISO19139EdenSchema,
+    def assert_passes_all_gemini2_validation(self, xml_filepath, gemini_schematron=validation.Gemini2Schematron):
+        _, errs = self.get_validation_errors(validation.ISO19139EdenSchema,
                                           xml_filepath)
         assert not errs, 'ISO19139EdenSchema: ' + errs
-        errs = self.get_validation_errors(validation.ConstraintsSchematron14,
+        _, errs = self.get_validation_errors(validation.ConstraintsSchematron14,
                                           xml_filepath)
         assert not errs, 'ConstraintsSchematron14: ' + errs
-        errs = self.get_validation_errors(validation.Gemini2Schematron,
+        _, errs = self.get_validation_errors(gemini_schematron,
                                           xml_filepath)
         assert not errs, 'Gemini2Schematron: ' + errs
 
     def test_04_dataset_valid(self):
-        self.assert_passes_all_gemini2_1_validation('gemini2.1/validation/04_Dataset_Valid.xml')
+        self.assert_passes_all_gemini2_validation('gemini2.1/validation/04_Dataset_Valid.xml')
 
     def test_05_series_fail_iso19139_schema(self):
-        errors = self.get_validation_errors(validation.ISO19139EdenSchema,
+        _, errors = self.get_validation_errors(validation.ISO19139EdenSchema,
              'gemini2.1/validation/05_Series_Invalid_XSD_No_Such_Element.xml')
         assert len(errors) > 0
         assert_in('(gmx.xsd)', errors)
         assert_in('\'{http://www.isotc211.org/2005/gmd}nosuchelement\': This element is not expected.', errors)
 
     def test_06_series_fail_constraints_schematron(self):
-        errors = self.get_validation_errors(validation.ConstraintsSchematron14,
+        _, errors = self.get_validation_errors(validation.ConstraintsSchematron14,
           'gemini2.1/validation/06_Series_Invalid_19139_Missing_Data_Format.xml')
         assert len(errors) > 0
         assert_in('MD_Distribution / MD_Format: count(distributionFormat + distributorFormat) > 0', errors)
 
     def test_07_series_fail_gemini_schematron(self):
-        errors = self.get_validation_errors(validation.Gemini2Schematron,
+        _, errors = self.get_validation_errors(validation.Gemini2Schematron,
             'gemini2.1/validation/07_Series_Invalid_GEMINI_Missing_Keyword.xml')
         assert len(errors) > 0
         assert_in('Descriptive keywords are mandatory', errors)
 
     def test_08_series_valid(self):
-        self.assert_passes_all_gemini2_1_validation('gemini2.1/validation/08_Series_Valid.xml')
+        self.assert_passes_all_gemini2_validation('gemini2.1/validation/08_Series_Valid.xml')
 
     def test_09_service_fail_iso19139_schema(self):
-        errors = self.get_validation_errors(validation.ISO19139EdenSchema,
+        _, errors = self.get_validation_errors(validation.ISO19139EdenSchema,
              'gemini2.1/validation/09_Service_Invalid_No_Such_Element.xml')
         assert len(errors) > 0
         assert_in('(gmx.xsd & srv.xsd)', errors)
         assert_in('\'{http://www.isotc211.org/2005/gmd}nosuchelement\': This element is not expected.', errors)
 
     def test_10_service_fail_constraints_schematron(self):
-        errors = self.get_validation_errors(validation.ConstraintsSchematron14,
+        _, errors = self.get_validation_errors(validation.ConstraintsSchematron14,
            'gemini2.1/validation/10_Service_Invalid_19139_Level_Description.xml')
         assert len(errors) > 0
         assert_in("DQ_Scope: 'levelDescription' is mandatory if 'level' notEqual 'dataset' or 'series'.", errors)
 
     def test_11_service_fail_gemini_schematron(self):
-        errors = self.get_validation_errors(validation.Gemini2Schematron,
+        _, errors = self.get_validation_errors(validation.Gemini2Schematron,
             'gemini2.1/validation/11_Service_Invalid_GEMINI_Service_Type.xml')
         assert len(errors) > 0
         assert_in("Service type shall be one of 'discovery', 'view', 'download', 'transformation', 'invoke' or 'other' following INSPIRE generic names.", errors)
 
     def test_12_service_valid(self):
-        self.assert_passes_all_gemini2_1_validation('gemini2.1/validation/12_Service_Valid.xml')
+        self.assert_passes_all_gemini2_validation('gemini2.1/validation/12_Service_Valid.xml')
 
     def test_13_dataset_fail_iso19139_schema_2(self):
         # This test Dataset has srv tags and only Service metadata should.
-        errors = self.get_validation_errors(validation.ISO19139EdenSchema,
+        _, errors = self.get_validation_errors(validation.ISO19139EdenSchema,
                  'gemini2.1/validation/13_Dataset_Invalid_Element_srv.xml')
         assert len(errors) > 0
         assert_in('(gmx.xsd)', errors)
         assert_in('Element \'{http://www.isotc211.org/2005/srv}SV_ServiceIdentification\': This element is not expected.', errors)
+
+    def test_14_gemini23_service_valid(self):
+        # BGSds-example1c.xml has validation errors, this may be intentional
+        for filename in ['1042-sv.xml', '1044-ds.xml', 'BGSsv-examplea1.xml']:
+            self.assert_passes_all_gemini2_validation(
+                'gemini2.3/validation/{}'.format(filename),
+                gemini_schematron=validation.Gemini2Schematron3)
+
+    def test_15_gemini23_service_invalid(self):
+        error_list, errors = self.get_validation_errors(validation.Gemini2Schematron3,
+                 'gemini2.3/validation/InvalidGemini2_3.xml')
+        assert len(error_list) == 7
+        assert_in('MI-4b (Abstract): Abstract is too short. GEMINI 2.3', errors)
+        assert_in('MI-33 (Metadata Language): Metadata language is mandatory', errors)
+        assert_in('MI-41a (Conformity): There must be at least one gmd:DQ_ConformanceResult', errors)
+        assert_in('MI-48a (Quality Scope): There must be at least one', errors)
+        assert_in('MI-48d (Quality Scope): There shall be exactly one', errors)
+        assert_in('AT-8: There must be at least two Legal Constraints sections (gmd:resourceConstraints/gmd:MD_LegalConstraints) in the metadata but we have 1', errors)
+        assert_in('AT-7: There shall not be more than one revision date.', errors)
 
     def test_schematron_error_extraction(self):
         validation_error_xml = '''

--- a/ckanext/spatial/tests/xml/gemini2.3/validation/1042-sv.xml
+++ b/ckanext/spatial/tests/xml/gemini2.3/validation/1042-sv.xml
@@ -1,0 +1,821 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gsr="http://www.isotc211.org/2005/gsr"
+    xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts"
+    xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <gmd:fileIdentifier>
+        <gco:CharacterString>a0a82d76-657c-2a78-e044-0003ba9b0d98</gco:CharacterString>
+    </gmd:fileIdentifier>
+    <gmd:language>
+        <gmd:LanguageCode
+            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#LanguageCode"
+            codeListValue="eng">English</gmd:LanguageCode>
+    </gmd:language>
+    <gmd:hierarchyLevel>
+        <gmd:MD_ScopeCode
+            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_ScopeCode"
+            codeListValue="service">service</gmd:MD_ScopeCode>
+    </gmd:hierarchyLevel>
+    <gmd:hierarchyLevelName>
+        <gco:CharacterString>service</gco:CharacterString>
+    </gmd:hierarchyLevelName>
+    <gmd:contact>
+        <gmd:CI_ResponsibleParty>
+            <gmd:organisationName>
+                <gco:CharacterString>British Geological Survey</gco:CharacterString>
+            </gmd:organisationName>
+            <gmd:contactInfo>
+                <gmd:CI_Contact>
+                    <gmd:phone>
+                        <gmd:CI_Telephone>
+                            <gmd:voice>
+                                <gco:CharacterString>+44 115 936 3100 Ex:3115</gco:CharacterString>
+                            </gmd:voice>
+                        </gmd:CI_Telephone>
+                    </gmd:phone>
+                    <gmd:address>
+                        <gmd:CI_Address>
+                            <gmd:deliveryPoint>
+                                <gco:CharacterString>Murchison House, West Mains Road, Edinburgh,
+                                    Lothian, United Kingdom, EH9 3LA, NG12 5GG</gco:CharacterString>
+                            </gmd:deliveryPoint>
+                            <gmd:city>
+                                <gco:CharacterString>EDINBURGH</gco:CharacterString>
+                            </gmd:city>
+                            <gmd:administrativeArea>
+                                <gco:CharacterString>LOTHIAN</gco:CharacterString>
+                            </gmd:administrativeArea>
+                            <gmd:postalCode>
+                                <gco:CharacterString>EH9 3LA</gco:CharacterString>
+                            </gmd:postalCode>
+                            <gmd:country>
+                                <gco:CharacterString>United Kingdom</gco:CharacterString>
+                            </gmd:country>
+                            <gmd:electronicMailAddress>
+                                <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                            </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                    </gmd:address>
+                </gmd:CI_Contact>
+            </gmd:contactInfo>
+            <gmd:role>
+                <gmd:CI_RoleCode
+                    codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode"
+                    codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+            </gmd:role>
+        </gmd:CI_ResponsibleParty>
+    </gmd:contact>
+    <gmd:dateStamp>
+        <gco:Date>2011-04-11</gco:Date>
+    </gmd:dateStamp>
+    <gmd:metadataStandardName>
+        <gco:CharacterString>ISO19115:2003(E)</gco:CharacterString>
+    </gmd:metadataStandardName>
+    <gmd:metadataStandardVersion>
+        <gco:CharacterString>GEMINI:2</gco:CharacterString>
+    </gmd:metadataStandardVersion>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode
+                                            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                            codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/4258">ETRS89-GRS80</gmx:Anchor>
+                    </gmd:code>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:identificationInfo>
+        <srv:SV_ServiceIdentification>
+            <gmd:citation>
+                <gmd:CI_Citation>
+                    <gmd:title>
+                        <gco:CharacterString>BGS Surface geology (OGC WxS INSPIRE
+                            IOC)</gco:CharacterString>
+                    </gmd:title>
+                    <gmd:date>
+                        <gmd:CI_Date>
+                            <gmd:date>
+                                <gco:Date>1995</gco:Date>
+                            </gmd:date>
+                            <gmd:dateType>
+                                <gmd:CI_DateTypeCode
+                                    codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                    codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                            </gmd:dateType>
+                        </gmd:CI_Date>
+                    </gmd:date>
+                    <gmd:identifier>
+                        <gmd:MD_Identifier>
+                            <gmd:code>
+                                <gmx:Anchor
+                                    xlink:href="http://data.bgs.ac.uk/id/dataHolding/13605559">BGS
+                                    Surface geology</gmx:Anchor>
+                            </gmd:code>
+                        </gmd:MD_Identifier>
+                    </gmd:identifier>
+                </gmd:CI_Citation>
+            </gmd:citation>
+            <gmd:abstract>
+                <gco:CharacterString>Data from the DiGMap covering the whole of the United Kingdom
+                    at a scale of 1:625 000 is available in this OGC WMS service for personal,
+                    non-commercial use only. The service is a contribution to the OneGeology-Europe
+                    initiative. The layers can be displayed either by age or by lithology. For more
+                    information about the digital maps available from the British Geological Survey,
+                    please visit
+                    http://www.bgs.ac.uk/products/digitalmaps/digmapgb.html.</gco:CharacterString>
+            </gmd:abstract>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:individualName>
+                        <gco:CharacterString>Westhead,Keith Robert</gco:CharacterString>
+                    </gmd:individualName>
+                    <gmd:organisationName>
+                        <gco:CharacterString>British Geological Survey</gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:positionName>
+                        <gco:CharacterString>HoS - Information Delivery</gco:CharacterString>
+                    </gmd:positionName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:phone>
+                                <gmd:CI_Telephone>
+                                    <gmd:voice>
+                                        <gco:CharacterString>+44 131 667 1000
+                                            Ex:364</gco:CharacterString>
+                                    </gmd:voice>
+                                </gmd:CI_Telephone>
+                            </gmd:phone>
+                            <gmd:address>
+                                <gmd:CI_Address>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>Murchison House, West Mains Road,
+                                            Edinburgh, Lothian, United Kingdom, EH9 3LA, NG12
+                                            5GG</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:city>
+                                        <gco:CharacterString>EDINBURGH</gco:CharacterString>
+                                    </gmd:city>
+                                    <gmd:administrativeArea>
+                                        <gco:CharacterString>LOTHIAN</gco:CharacterString>
+                                    </gmd:administrativeArea>
+                                    <gmd:postalCode>
+                                        <gco:CharacterString>EH9 3LA</gco:CharacterString>
+                                    </gmd:postalCode>
+                                    <gmd:country>
+                                        <gco:CharacterString>United Kingdom</gco:CharacterString>
+                                    </gmd:country>
+                                    <gmd:electronicMailAddress>
+                                        <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                </gmd:CI_Address>
+                            </gmd:address>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode
+                            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode"
+                            codeListValue="distributor">distributor</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:resourceMaintenance>
+                <gmd:MD_MaintenanceInformation>
+                    <gmd:maintenanceAndUpdateFrequency>
+                        <gmd:MD_MaintenanceFrequencyCode
+                            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode"
+                            codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+                    </gmd:maintenanceAndUpdateFrequency>
+                </gmd:MD_MaintenanceInformation>
+            </gmd:resourceMaintenance>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>Geology</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>GEMET Thesaurus version
+                                    1.0</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2009-06-30</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode
+                                            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                            codeListValue="publication"
+                                            >publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>Maps</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>Digital maps</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>Spatial data</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>Geology</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>Data</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>BGS Thesaurus of
+                                    Geosciences</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2009</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode
+                                            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                            codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>infoMapAccessService</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>ISO 19119:2005</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2008-04-16</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode
+                                            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                            codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>NERC_DDC</gco:CharacterString>
+                    </gmd:keyword>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:resourceConstraints>
+                <gmd:MD_LegalConstraints>
+                    <gmd:accessConstraints>
+                        <gmd:MD_RestrictionCode
+                            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_RestrictionCode"
+                            codeListValue="otherRestrictions"
+                            >otherRestrictions</gmd:MD_RestrictionCode>
+                    </gmd:accessConstraints>
+                    <gmd:otherConstraints>
+                        <gmx:Anchor
+                            xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations"
+                            >no limitations</gmx:Anchor>
+                    </gmd:otherConstraints>
+                </gmd:MD_LegalConstraints>
+            </gmd:resourceConstraints>
+            <gmd:resourceConstraints>
+                <gmd:MD_LegalConstraints>
+                    <gmd:useConstraints>
+                        <gmd:MD_RestrictionCode
+                            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_RestrictionCode"
+                            codeListValue="otherRestrictions"
+                            >otherRestrictions</gmd:MD_RestrictionCode>
+                    </gmd:useConstraints>
+                    <gmd:otherConstraints>
+                        <gco:CharacterString>The 1:625k DiGMap data is made available for all uses -
+                            including commercial use, however the British Geological Survey (BGS) at
+                            all times retains the copyright in this material and you are not
+                            permitted, without an appropriate licence, to set up a service selling
+                            on this material. Your own use of any information provided by the
+                            British Geological Survey (BGS) is at your own risk. Neither BGS nor the
+                            Natural Environment Research Council (NERC) gives any warranty,
+                            condition or representation as to the quality, accuracy or completeness
+                            of the information or its suitability for any use or purpose. All
+                            implied conditions relating to the quality or suitability of the
+                            information, and all liabilities arising from the supply of the
+                            information (including any liability arising in negligence) are excluded
+                            to the fullest extent permitted by law.</gco:CharacterString>
+                    </gmd:otherConstraints>
+                </gmd:MD_LegalConstraints>
+            </gmd:resourceConstraints>
+            <srv:serviceType>
+                <gco:LocalName codeSpace="INSPIRE">view</gco:LocalName>
+            </srv:serviceType>
+            <srv:extent>
+                <gmd:EX_Extent>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicDescription>
+                            <gmd:geographicIdentifier>
+                                <gmd:MD_Identifier>
+                                    <gmd:authority>
+                                        <gmd:CI_Citation>
+                                            <gmd:title>
+                                                <gco:CharacterString>ISO
+                                                  3166_2</gco:CharacterString>
+                                            </gmd:title>
+                                            <gmd:date>
+                                                <gmd:CI_Date>
+                                                  <gmd:date>
+                                                  <gco:Date>2009-01-07</gco:Date>
+                                                  </gmd:date>
+                                                  <gmd:dateType>
+                                                  <gmd:CI_DateTypeCode
+                                                  codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                                  codeListValue="revision"
+                                                  >revision</gmd:CI_DateTypeCode>
+                                                  </gmd:dateType>
+                                                </gmd:CI_Date>
+                                            </gmd:date>
+                                        </gmd:CI_Citation>
+                                    </gmd:authority>
+                                    <gmd:code>
+                                        <gco:CharacterString>UKM</gco:CharacterString>
+                                    </gmd:code>
+                                </gmd:MD_Identifier>
+                            </gmd:geographicIdentifier>
+                        </gmd:EX_GeographicDescription>
+                    </gmd:geographicElement>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicDescription>
+                            <gmd:geographicIdentifier>
+                                <gmd:MD_Identifier>
+                                    <gmd:authority>
+                                        <gmd:CI_Citation>
+                                            <gmd:title>
+                                                <gco:CharacterString>ISO
+                                                  3166_1</gco:CharacterString>
+                                            </gmd:title>
+                                            <gmd:date>
+                                                <gmd:CI_Date>
+                                                  <gmd:date>
+                                                  <gco:Date>2009-01-07</gco:Date>
+                                                  </gmd:date>
+                                                  <gmd:dateType>
+                                                  <gmd:CI_DateTypeCode
+                                                  codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                                  codeListValue="revision"
+                                                  >revision</gmd:CI_DateTypeCode>
+                                                  </gmd:dateType>
+                                                </gmd:CI_Date>
+                                            </gmd:date>
+                                        </gmd:CI_Citation>
+                                    </gmd:authority>
+                                    <gmd:code>
+                                        <gco:CharacterString>GB</gco:CharacterString>
+                                    </gmd:code>
+                                </gmd:MD_Identifier>
+                            </gmd:geographicIdentifier>
+                        </gmd:EX_GeographicDescription>
+                    </gmd:geographicElement>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicBoundingBox>
+                            <gmd:westBoundLongitude>
+                                <gco:Decimal>-6.8647</gco:Decimal>
+                            </gmd:westBoundLongitude>
+                            <gmd:eastBoundLongitude>
+                                <gco:Decimal>2.9603</gco:Decimal>
+                            </gmd:eastBoundLongitude>
+                            <gmd:southBoundLatitude>
+                                <gco:Decimal>49.7974</gco:Decimal>
+                            </gmd:southBoundLatitude>
+                            <gmd:northBoundLatitude>
+                                <gco:Decimal>60.7719</gco:Decimal>
+                            </gmd:northBoundLatitude>
+                        </gmd:EX_GeographicBoundingBox>
+                    </gmd:geographicElement>
+                    <gmd:temporalElement>
+                        <gmd:EX_TemporalExtent>
+                            <gmd:extent>
+                                <gml:TimePeriod gml:id="ID1">
+                                    <gml:beginPosition>1995</gml:beginPosition>
+                                    <gml:endPosition>1995</gml:endPosition>
+                                </gml:TimePeriod>
+                            </gmd:extent>
+                        </gmd:EX_TemporalExtent>
+                    </gmd:temporalElement>
+                </gmd:EX_Extent>
+            </srv:extent>
+            <srv:couplingType>
+                <srv:SV_CouplingType codeListValue="tight"
+                    codeList="http://www.isotc211.org/2005/iso19119/resources/codelist/gmxCodelists.xml#SV_CouplingType"
+                />
+            </srv:couplingType>
+            <srv:containsOperations gco:nilReason="missing"/>
+            <srv:operatesOn xlink:title="BGS.1M.surface.GeologicUnit"
+                xlink:href="http://ogcdev.bgs.ac.uk/geonetwork/srv/en/csw?SERVICE=CSW&amp;amp;REQUEST=GetRecordById&amp;amp;ID=9df8df52-d788-37a8-e044-0003ba9b0d98&amp;amp;elementSetName=full&amp;amp;OutputSchema=http://www.isotc211.org/2005/gmd&amp;amp;"
+                uuidref="9df8df52-d788-37a8-e044-0003ba9b0d98"/>
+            <srv:operatesOn xlink:title="BGS.1M.surface.GeologicUnit.age"
+                xlink:href="http://ogcdev.bgs.ac.uk/geonetwork/srv/en/csw?SERVICE=CSW&amp;amp;REQUEST=GetRecordById&amp;amp;ID=9df8df52-d788-37a8-e044-0003ba9b0d98&amp;amp;elementSetName=full&amp;amp;OutputSchema=http://www.isotc211.org/2005/gmd&amp;amp;"
+                uuidref="9df8df52-d788-37a8-e044-0003ba9b0d98"/>
+        </srv:SV_ServiceIdentification>
+    </gmd:identificationInfo>
+    <gmd:distributionInfo>
+        <gmd:MD_Distribution>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/gif</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version>
+                        <gco:CharacterString>NotApplicable</gco:CharacterString>
+                    </gmd:version>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/png; mode=24bit</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version>
+                        <gco:CharacterString>NotApplicable</gco:CharacterString>
+                    </gmd:version>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/jpeg</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version>
+                        <gco:CharacterString>NotApplicable</gco:CharacterString>
+                    </gmd:version>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/png</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version>
+                        <gco:CharacterString>NotApplicable</gco:CharacterString>
+                    </gmd:version>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/vnd.wap.wbmp</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version>
+                        <gco:CharacterString>NotApplicable</gco:CharacterString>
+                    </gmd:version>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/tiff</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version>
+                        <gco:CharacterString>NotApplicable</gco:CharacterString>
+                    </gmd:version>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/svg+xml</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version>
+                        <gco:CharacterString>NotApplicable</gco:CharacterString>
+                    </gmd:version>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>text/xml; subtype=gml/3.1.1</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version>
+                        <gco:CharacterString>3.1.1</gco:CharacterString>
+                    </gmd:version>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>GeoSciML</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version>
+                        <gco:CharacterString>2</gco:CharacterString>
+                    </gmd:version>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>text/plain</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>text/html</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>application/vnd.ogc.gml</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>text/xml</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="unknown"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributor>
+                <gmd:MD_Distributor>
+                    <gmd:distributorContact>
+                        <gmd:CI_ResponsibleParty>
+                            <gmd:organisationName>
+                                <gco:CharacterString>British Geological Survey</gco:CharacterString>
+                            </gmd:organisationName>
+                            <gmd:contactInfo>
+                                <gmd:CI_Contact>
+                                    <gmd:phone>
+                                        <gmd:CI_Telephone>
+                                            <gmd:voice>
+                                                <gco:CharacterString>+44 131 667 1000
+                                                  Ex:364</gco:CharacterString>
+                                            </gmd:voice>
+                                        </gmd:CI_Telephone>
+                                    </gmd:phone>
+                                    <gmd:address>
+                                        <gmd:CI_Address>
+                                            <gmd:deliveryPoint>
+                                                <gco:CharacterString>Murchison House, West Mains
+                                                  Road, Edinburgh, Lothian, United Kingdom, EH9 3LA,
+                                                  NG12 5GG</gco:CharacterString>
+                                            </gmd:deliveryPoint>
+                                            <gmd:city>
+                                                <gco:CharacterString>EDINBURGH</gco:CharacterString>
+                                            </gmd:city>
+                                            <gmd:administrativeArea>
+                                                <gco:CharacterString>LOTHIAN</gco:CharacterString>
+                                            </gmd:administrativeArea>
+                                            <gmd:postalCode>
+                                                <gco:CharacterString>EH9 3LA</gco:CharacterString>
+                                            </gmd:postalCode>
+                                            <gmd:country>
+                                                <gco:CharacterString>United
+                                                  Kingdom</gco:CharacterString>
+                                            </gmd:country>
+                                            <gmd:electronicMailAddress>
+                                                <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                                            </gmd:electronicMailAddress>
+                                        </gmd:CI_Address>
+                                    </gmd:address>
+                                </gmd:CI_Contact>
+                            </gmd:contactInfo>
+                            <gmd:role>
+                                <gmd:CI_RoleCode
+                                    codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode"
+                                    codeListValue="distributor">distributor</gmd:CI_RoleCode>
+                            </gmd:role>
+                        </gmd:CI_ResponsibleParty>
+                    </gmd:distributorContact>
+                </gmd:MD_Distributor>
+            </gmd:distributor>
+            <gmd:transferOptions>
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:onLine>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://ogc.bgs.ac.uk/BGS_Bedrock_and_Surface_Geology/wms.php?SERVICE=WMS&amp;REQUEST=getCapabilities&amp;</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>OGC:WMS-1.3.0-http-get-capabilities</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:name>
+                                <gco:CharacterString>BGS.Bedrock.and.Surface.Geology</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                                <gco:CharacterString>BGS Bedrock and Surface
+                                    geology</gco:CharacterString>
+                            </gmd:description>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode
+                                    codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
+                                    codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+            <gmd:transferOptions>
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:onLine>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://ogc.bgs.ac.uk/BGS_Bedrock_and_Surface_Geology/wms.php</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>OGC:WMS-1.3.0-http-get-map</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:name>
+                                <gco:CharacterString>BGS.1M.surface.GeologicUnit.age</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                                <gco:CharacterString>BGS 1M surface Geologic Unit Age. The layer
+                                    shows the rocks and superficial deposits present at the land
+                                    surface, clasified by Geological age</gco:CharacterString>
+                            </gmd:description>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode
+                                    codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
+                                    codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+            <gmd:transferOptions>
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:onLine>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://ogc.bgs.ac.uk/BGS_Bedrock_and_Surface_Geology/wms.php</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>OGC:WMS-1.3.0-http-get-map</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:name>
+                                <gco:CharacterString>BGS.1M.surface.GeologicUnit</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                                <gco:CharacterString>BGS 1M surface Geologic Unit. The layer shows
+                                    the rocks and superficial deposits present at the land surface,
+                                    clasified by lithology</gco:CharacterString>
+                            </gmd:description>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode
+                                    codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
+                                    codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+        </gmd:MD_Distribution>
+    </gmd:distributionInfo>
+    <gmd:dataQualityInfo>
+        <gmd:DQ_DataQuality>
+            <gmd:scope>
+                <gmd:DQ_Scope>
+                    <gmd:level>
+                        <gmd:MD_ScopeCode
+                            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_ScopeCode"
+                            codeListValue="service">service</gmd:MD_ScopeCode>
+                    </gmd:level>
+                    <gmd:levelDescription>
+                        <gmd:MD_ScopeDescription>
+                            <gmd:other>
+                                <gco:CharacterString>service</gco:CharacterString>
+                            </gmd:other>
+                        </gmd:MD_ScopeDescription>
+                    </gmd:levelDescription>
+                </gmd:DQ_Scope>
+            </gmd:scope>
+            <gmd:report>
+                <gmd:DQ_DomainConsistency>
+                    <gmd:result>
+                        <gmd:DQ_ConformanceResult>
+                            <gmd:specification>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                        <gco:CharacterString>Commission Regulation (EU) No 1089/2010
+                                            of 23 November 2010 implementing Directive 2007/2/EC of
+                                            the European Parliament and of the Council as regards
+                                            interoperability of spatial data sets and
+                                            services</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                        <gmd:CI_Date>
+                                            <gmd:date>
+                                                <gco:Date>2010-12-08</gco:Date>
+                                            </gmd:date>
+                                            <gmd:dateType>
+                                                <gmd:CI_DateTypeCode
+                                                  codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmx                                                    Codelists.xml#CI_DateTypeCode"
+                                                  codeListValue="publication"
+                                                  >publication</gmd:CI_DateTypeCode>
+                                            </gmd:dateType>
+                                        </gmd:CI_Date>
+                                    </gmd:date>
+                                </gmd:CI_Citation>
+                            </gmd:specification>
+                            <gmd:explanation>
+                                <gco:CharacterString>See
+                                    http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=OJ:L:2010:323:0011:0102:EN:PDF</gco:CharacterString>
+                            </gmd:explanation>
+                            <gmd:pass>
+                                <gco:Boolean>true</gco:Boolean>
+                            </gmd:pass>
+                        </gmd:DQ_ConformanceResult>
+                    </gmd:result>
+                    <gmd:result>
+                        <gmd:DQ_ConformanceResult>
+                            <gmd:specification>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                        <gco:CharacterString>Technical Guidance for the
+                                            implementation of INSPIRE View Services Version
+                                            3.0</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                        <gmd:CI_Date>
+                                            <gmd:date>
+                                                <gco:Date>2011-03-21</gco:Date>
+                                            </gmd:date>
+                                            <gmd:dateType>
+                                                <gmd:CI_DateTypeCode
+                                                  codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmx                                                     Codelists.xml#CI_DateTypeCode"
+                                                  codeListValue="publication"
+                                                  >publication</gmd:CI_DateTypeCode>
+                                            </gmd:dateType>
+                                        </gmd:CI_Date>
+                                    </gmd:date>
+                                </gmd:CI_Citation>
+                            </gmd:specification>
+                            <gmd:explanation>
+                                <gco:CharacterString>See the referenced specification at
+                                    http://inspire.jrc.ec.europa.eu/documents/Network_Services/TechnicalGuidance_ViewServices_v3.0.pdf</gco:CharacterString>
+                            </gmd:explanation>
+                            <gmd:pass>
+                                <gco:Boolean>true</gco:Boolean>
+                            </gmd:pass>
+                        </gmd:DQ_ConformanceResult>
+                    </gmd:result>
+                </gmd:DQ_DomainConsistency>
+            </gmd:report>
+            <gmd:lineage>
+                <gmd:LI_Lineage>
+                    <gmd:statement>
+                        <gco:CharacterString>For lineage of datasets served by this service please
+                            refer to the metadata for those data</gco:CharacterString>
+                    </gmd:statement>
+                </gmd:LI_Lineage>
+            </gmd:lineage>
+        </gmd:DQ_DataQuality>
+    </gmd:dataQualityInfo>
+</gmd:MD_Metadata>

--- a/ckanext/spatial/tests/xml/gemini2.3/validation/1044-ds.xml
+++ b/ckanext/spatial/tests/xml/gemini2.3/validation/1044-ds.xml
@@ -1,0 +1,582 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gsr="http://www.isotc211.org/2005/gsr"
+    xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts"
+    xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:geonet="http://www.fao.org/geonetwork"
+    xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://inspire.ec.europa.eu/draft-schemas/inspire-md-schemas/apiso-inspire/apiso-inspire.xsd">
+    <gmd:fileIdentifier>
+        <gco:CharacterString>ae0e855d-f0a2-438e-855c-6ef5400f4ef3</gco:CharacterString>
+    </gmd:fileIdentifier>
+    <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/php/code_list.php" codeListValue="eng">eng</gmd:LanguageCode>
+    </gmd:language>
+    <gmd:hierarchyLevel>
+        <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+    </gmd:hierarchyLevel>
+    <gmd:contact>
+        <gmd:CI_ResponsibleParty>
+            <gmd:organisationName>
+                <gco:CharacterString>Ordnance Survey, Great Britain</gco:CharacterString>
+            </gmd:organisationName>
+            <gmd:positionName>
+                <gco:CharacterString>Customer Services</gco:CharacterString>
+            </gmd:positionName>
+            <gmd:contactInfo>
+                <gmd:CI_Contact>
+                    <gmd:phone>
+                        <gmd:CI_Telephone>
+                            <gmd:voice>
+                                <gco:CharacterString>+44 (0)8456 050505</gco:CharacterString>
+                            </gmd:voice>
+                        </gmd:CI_Telephone>
+                    </gmd:phone>
+                    <gmd:address>
+                        <gmd:CI_Address>
+                            <gmd:deliveryPoint>
+                                <gco:CharacterString>Explorer House, Adanac Drive</gco:CharacterString>
+                            </gmd:deliveryPoint>
+                            <gmd:city>
+                                <gco:CharacterString>Southampton</gco:CharacterString>
+                            </gmd:city>
+                            <gmd:postalCode>
+                                <gco:CharacterString>SO16 0AS</gco:CharacterString>
+                            </gmd:postalCode>
+                            <gmd:country>
+                                <gco:CharacterString>United Kingdom</gco:CharacterString>
+                            </gmd:country>
+                            <gmd:electronicMailAddress>
+                                <gco:CharacterString>customerservices@ordnancesurvey.co.uk</gco:CharacterString>
+                            </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                    </gmd:address>
+                </gmd:CI_Contact>
+            </gmd:contactInfo>
+            <gmd:role>
+                <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+            </gmd:role>
+        </gmd:CI_ResponsibleParty>
+    </gmd:contact>
+    <gmd:dateStamp>
+        <gco:DateTime>2010-12-02T11:39:34</gco:DateTime>
+    </gmd:dateStamp>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:code>
+                        <gco:CharacterString> http://www.opengis.net/def/crs/EPSG/0/27700</gco:CharacterString>
+                    </gmd:code>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:identificationInfo>
+        <gmd:MD_DataIdentification>
+            <gmd:citation>
+                <gmd:CI_Citation>
+                    <gmd:title>
+                        <gco:CharacterString>Boundary-Line™</gco:CharacterString>
+                    </gmd:title>
+                    <gmd:date>
+                        <gmd:CI_Date>
+                            <gmd:date>
+                                <gco:Date>1996-04-01</gco:Date>
+                            </gmd:date>
+                            <gmd:dateType>
+                                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                            </gmd:dateType>
+                        </gmd:CI_Date>
+                    </gmd:date>
+                    <gmd:identifier>
+                        <gmd:RS_Identifier>
+                            <gmd:code>
+                                <gco:CharacterString>Boundary-Line™</gco:CharacterString>
+                            </gmd:code>
+                        </gmd:RS_Identifier>
+                    </gmd:identifier>
+                </gmd:CI_Citation>
+            </gmd:citation>
+            <gmd:abstract>
+                <gco:CharacterString>Boundary-Line is a specialist 1:10 000 scale boundaries dataset. It contains all levels of electoral and administrative boundaries, from district, wards and civil parishes (or communities) up to parliamentary, assembly and European constituencies.
+ 
+
+The information is represented as vector digital data.  
+
+ 
+
+The boundary information is updated twice a year, in May and October. The May release contains the boundaries that have become live in the first week of May, in the year of release. The October release contains the May boundaries plus additional information. Customers can choose either May or October releases.
+
+ 
+
+    * County - The named  county, district, district ward, civil parish, county electoral division (ED).
+
+    * European constituencies - The named European region.
+
+    * Greater London Authority  - The Greater London Authority, Greater London Authority Assembly constituency, London borough, London borough ward.
+
+    * Metropolitan districts - The named metropolitan district, metropolitan district ward, civil parish where appropriate.
+
+    * Scottish parliamentary electoral region - The named Scottish Parliamentary electoral region, Scottish parliamentary constituency.
+
+    * Unitary authorities- The named unitary authority, unitary authority ward or unitary authority ED as appropriate, civil parish where appropriate, together with community in Wales.
+
+    * Welsh Assembly Electoral Region - The named Welsh Assembly electoral region, Welsh assembly constituency.
+
+    * Westminster constituencies - The named Westminster constituency.
+
+    * Extent of the realm -  Low water mark or seaward boundary extension.
+
+    * High water mark
+
+    * Unique identifiers -   For administrative areas, polygons and links.
+
+    * Area measurements
+
+    * Definitive names
+
+    * Census codes</gco:CharacterString>
+            </gmd:abstract>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+
+                    <gmd:organisationName>
+                        <gco:CharacterString>Ordnance Survey, Great Britain</gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:positionName>
+                        <gco:CharacterString>Customer Services</gco:CharacterString>
+                    </gmd:positionName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:phone>
+                                <gmd:CI_Telephone>
+                                    <gmd:voice>
+                                        <gco:CharacterString>+44 (0)8456 050505</gco:CharacterString>
+                                    </gmd:voice>
+                                </gmd:CI_Telephone>
+                            </gmd:phone>
+                            <gmd:address>
+                                <gmd:CI_Address>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>Explorer House, Adanac Drive</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:city>
+                                        <gco:CharacterString>Southampton</gco:CharacterString>
+                                    </gmd:city>
+                                    <gmd:postalCode>
+                                        <gco:CharacterString>SO16 0AS</gco:CharacterString>
+                                    </gmd:postalCode>
+                                    <gmd:country>
+                                        <gco:CharacterString>United Kingdom</gco:CharacterString>
+                                    </gmd:country>
+                                    <gmd:electronicMailAddress>
+                                        <gco:CharacterString>customerservices@ordnancesurvey.co.uk</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                </gmd:CI_Address>
+                            </gmd:address>
+                            <gmd:onlineResource>
+
+                                <gmd:CI_OnlineResource>
+
+                                    <gmd:linkage>
+
+                                        <gmd:URL>http://www.ordnancesurvey.co.uk/</gmd:URL>
+
+                                    </gmd:linkage>
+
+                                    <gmd:description>
+
+                                        <gco:CharacterString>Ordnance Survey, Great Britain top level website</gco:CharacterString>
+
+                                    </gmd:description>
+
+                                </gmd:CI_OnlineResource>
+
+                            </gmd:onlineResource>
+
+                        </gmd:CI_Contact>
+
+                    </gmd:contactInfo>
+
+                    <gmd:role>
+
+                        <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="publisher">publisher</gmd:CI_RoleCode>
+
+                    </gmd:role>
+
+                </gmd:CI_ResponsibleParty>
+
+            </gmd:pointOfContact>
+
+            <gmd:resourceMaintenance>
+
+                <gmd:MD_MaintenanceInformation>
+
+                    <gmd:maintenanceAndUpdateFrequency>
+
+                        <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="biannually">biannually</gmd:MD_MaintenanceFrequencyCode>
+
+                    </gmd:maintenanceAndUpdateFrequency>
+
+                </gmd:MD_MaintenanceInformation>
+
+            </gmd:resourceMaintenance>
+
+            <gmd:graphicOverview>
+
+                <gmd:MD_BrowseGraphic>
+
+                    <gmd:fileName>
+
+                        <gco:CharacterString>BoundaryLine_s.png</gco:CharacterString>
+
+                    </gmd:fileName>
+
+                    <gmd:fileDescription>
+
+                        <gco:CharacterString>thumbnail</gco:CharacterString>
+
+                    </gmd:fileDescription>
+
+                    <gmd:fileType>
+
+                        <gco:CharacterString>png</gco:CharacterString>
+
+                    </gmd:fileType>
+
+                </gmd:MD_BrowseGraphic>
+
+            </gmd:graphicOverview>
+            <gmd:descriptiveKeywords>
+
+                <gmd:MD_Keywords>
+
+                    <gmd:keyword>
+
+                        <gco:CharacterString>Geographical names</gco:CharacterString>
+
+                    </gmd:keyword>
+
+                    <gmd:thesaurusName>
+
+                        <gmd:CI_Citation>
+
+                            <gmd:title>
+
+                                <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
+
+                            </gmd:title>
+
+                            <gmd:date>
+
+                                <gmd:CI_Date>
+
+                                    <gmd:date>
+
+                                        <gco:Date>2008-06-01</gco:Date>
+
+                                    </gmd:date>
+
+                                    <gmd:dateType>
+
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+
+                                    </gmd:dateType>
+
+                                </gmd:CI_Date>
+
+                            </gmd:date>
+
+                        </gmd:CI_Citation>
+
+                    </gmd:thesaurusName>
+
+                </gmd:MD_Keywords>
+
+            </gmd:descriptiveKeywords>
+
+            <gmd:descriptiveKeywords>
+
+                <gmd:MD_Keywords>
+
+                    <gmd:keyword>
+
+                        <gco:CharacterString>Legal government boundaries</gco:CharacterString>
+
+                    </gmd:keyword>
+
+                    <gmd:keyword>
+
+                        <gco:CharacterString>Mapping</gco:CharacterString>
+
+                    </gmd:keyword>
+
+                    <gmd:keyword>
+
+                        <gco:CharacterString>Mid-Scales</gco:CharacterString>
+
+                    </gmd:keyword>
+
+                    <gmd:keyword>
+
+                        <gco:CharacterString>Electorial Boundaries</gco:CharacterString>
+
+                    </gmd:keyword>
+
+                    <gmd:keyword>
+
+                        <gco:CharacterString>administrative boundaries</gco:CharacterString>
+
+                    </gmd:keyword>
+
+                    <gmd:keyword>
+
+                        <gco:CharacterString>GSS codes</gco:CharacterString>
+
+                    </gmd:keyword>
+
+                    <gmd:keyword>
+
+                        <gco:CharacterString>Ordnance Survey</gco:CharacterString>
+
+                    </gmd:keyword>
+
+                    <gmd:keyword>
+
+                        <gco:CharacterString>OS</gco:CharacterString>
+
+                    </gmd:keyword>
+
+                </gmd:MD_Keywords>
+
+            </gmd:descriptiveKeywords>
+            <gmd:resourceConstraints>
+                <gmd:MD_LegalConstraints>
+                    <gmd:accessConstraints>
+                        <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
+                    </gmd:accessConstraints>
+                    <gmd:otherConstraints>
+                        <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/INSPIRE_Directive_Article13_1e">Public access to spatial data sets and services would adversely affect intellectual property rights.</gmx:Anchor>
+                    </gmd:otherConstraints>
+                    <gmd:otherConstraints>
+                        <gco:CharacterString>For further details on licensing see http://www.ordnancesurvey.co.uk/oswebsite/business/licences/index.html</gco:CharacterString>
+                    </gmd:otherConstraints>
+                </gmd:MD_LegalConstraints>
+            </gmd:resourceConstraints>
+            <gmd:resourceConstraints>
+                <gmd:MD_LegalConstraints>
+                    <gmd:useConstraints>
+                        <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
+                    </gmd:useConstraints>
+                    <gmd:otherConstraints>
+                        <gmx:Anchor xlink:href="https://os.uk/business/licences/index.html">Use limitation dependent upon licence</gmx:Anchor>
+                    </gmd:otherConstraints>
+                </gmd:MD_LegalConstraints>
+            </gmd:resourceConstraints>
+            <gmd:spatialRepresentationType>
+                <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector"/>
+            </gmd:spatialRepresentationType>
+            <gmd:spatialResolution>
+
+                <gmd:MD_Resolution>
+
+                    <gmd:equivalentScale>
+
+                        <gmd:MD_RepresentativeFraction>
+
+                            <gmd:denominator>
+
+                                <gco:Integer>10000</gco:Integer>
+
+                            </gmd:denominator>
+
+                        </gmd:MD_RepresentativeFraction>
+
+                    </gmd:equivalentScale>
+
+                </gmd:MD_Resolution>
+
+            </gmd:spatialResolution>
+
+            <gmd:language>
+                <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/php/code_list.php" codeListValue="eng">English</gmd:LanguageCode>
+            </gmd:language>
+
+            <gmd:topicCategory>
+                <gmd:MD_TopicCategoryCode>boundaries</gmd:MD_TopicCategoryCode>
+            </gmd:topicCategory>
+
+            <gmd:extent>
+
+                <gmd:EX_Extent>
+
+                    <gmd:geographicElement>
+
+                        <gmd:EX_GeographicBoundingBox>
+
+                            <gmd:westBoundLongitude>
+
+                                <gco:Decimal>-8.45</gco:Decimal>
+
+                            </gmd:westBoundLongitude>
+
+                            <gmd:eastBoundLongitude>
+
+                                <gco:Decimal>1.78</gco:Decimal>
+
+                            </gmd:eastBoundLongitude>
+
+                            <gmd:southBoundLatitude>
+
+                                <gco:Decimal>49.86</gco:Decimal>
+
+                            </gmd:southBoundLatitude>
+
+                            <gmd:northBoundLatitude>
+
+                                <gco:Decimal>60.86</gco:Decimal>
+
+                            </gmd:northBoundLatitude>
+
+                        </gmd:EX_GeographicBoundingBox>
+
+                    </gmd:geographicElement>
+
+                    <gmd:temporalElement>
+
+                        <gmd:EX_TemporalExtent>
+
+                            <gmd:extent>
+
+                                <gml:TimePeriod gml:id="T1">
+
+                                    <gml:beginPosition>2010-06-01</gml:beginPosition>
+
+                                    <gml:endPosition>2010-09-30</gml:endPosition>
+
+                                </gml:TimePeriod>
+
+                            </gmd:extent>
+
+                        </gmd:EX_TemporalExtent>
+
+                    </gmd:temporalElement>
+
+                </gmd:EX_Extent>
+
+            </gmd:extent>
+
+        </gmd:MD_DataIdentification>
+
+    </gmd:identificationInfo>
+
+    <gmd:distributionInfo>
+
+        <gmd:MD_Distribution>
+
+            <gmd:distributionFormat>
+
+                <gmd:MD_Format>
+
+                    <gmd:name>
+
+                        <gco:CharacterString>ESRI® Spatial data format (Shapefile)</gco:CharacterString>
+
+                    </gmd:name>
+
+                    <gmd:version>
+
+                        <gco:CharacterString>1.0</gco:CharacterString>
+
+                    </gmd:version>
+
+                </gmd:MD_Format>
+
+            </gmd:distributionFormat>
+
+            <gmd:transferOptions>
+
+                <gmd:MD_DigitalTransferOptions>
+
+                    <gmd:onLine>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://www.ordnancesurvey.co.uk/oswebsite/products/boundaryline/</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:name>
+                                <gco:CharacterString>Ordnance Survey boundaryline</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                                <gco:CharacterString>From Euro constituencies to council wards, Boundary-Line™ maps every administrative boundary in detail for you. And what's more, it's completely free to download and use</gco:CharacterString>
+                            </gmd:description>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                            
+                        </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                </gmd:MD_DigitalTransferOptions>
+
+            </gmd:transferOptions>
+
+        </gmd:MD_Distribution>
+
+    </gmd:distributionInfo>
+
+    <gmd:dataQualityInfo>
+        <gmd:DQ_DataQuality>
+            <gmd:scope>
+                <gmd:DQ_Scope>
+                    <gmd:level>
+                        <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+                    </gmd:level>
+                </gmd:DQ_Scope>
+            </gmd:scope>
+            <gmd:report>
+                <gmd:DQ_DomainConsistency>
+                    <gmd:result>
+                        <gmd:DQ_ConformanceResult>
+                            <gmd:specification>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                        <gmx:Anchor xlink:href="http://data.europa.eu/eli/reg/2010/1089">Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services</gmx:Anchor>
+                                    </gmd:title>
+                                    <gmd:date>
+                                        <gmd:CI_Date>
+                                            <gmd:date>
+                                                <gco:Date>2010-12-08</gco:Date>
+                                            </gmd:date>
+                                            <gmd:dateType>
+                                                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
+                                            </gmd:dateType>
+                                        </gmd:CI_Date>
+                                    </gmd:date>
+                                </gmd:CI_Citation>
+                            </gmd:specification>
+                            <!-- Explanation is a required element but can be empty -->
+                            <gmd:explanation gco:nilReason="inapplicable"/>
+                            <!-- If not tested then -->
+                            <gmd:pass gco:nilReason="unknown"/>
+                        </gmd:DQ_ConformanceResult>
+                    </gmd:result>
+                </gmd:DQ_DomainConsistency>
+            </gmd:report>
+            <gmd:lineage>
+                <gmd:LI_Lineage>
+                    <gmd:statement>
+
+                        <gco:CharacterString>Captured and maintained solely from legal boundary changes</gco:CharacterString>
+
+                    </gmd:statement>
+
+                </gmd:LI_Lineage>
+
+            </gmd:lineage>
+
+        </gmd:DQ_DataQuality>
+
+    </gmd:dataQualityInfo>
+
+</gmd:MD_Metadata>

--- a/ckanext/spatial/tests/xml/gemini2.3/validation/BGSds-example1c.xml
+++ b/ckanext/spatial/tests/xml/gemini2.3/validation/BGSds-example1c.xml
@@ -1,0 +1,901 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+   xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml/3.2"
+   xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gsr="http://www.isotc211.org/2005/gsr"
+   xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts"
+   xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns:geonet="http://www.fao.org/geonetwork"
+   xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://inspire.ec.europa.eu/draft-schemas/inspire-md-schemas/apiso-inspire/apiso-inspire.xsd">
+   <gmd:fileIdentifier>
+      <gco:CharacterString>9df8df51-6332-37a8-e044-0003ba9b0d98</gco:CharacterString>
+   </gmd:fileIdentifier>
+   <gmd:language>
+      <gmd:LanguageCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#LanguageCode" codeListValue="eng">English</gmd:LanguageCode>
+   </gmd:language>
+   <gmd:parentIdentifier gco:nilReason="inapplicable"/>
+   <gmd:hierarchyLevel>
+      <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+   </gmd:hierarchyLevel>
+   <gmd:hierarchyLevelName gco:nilReason="inapplicable"/>
+   <gmd:contact>
+      <gmd:CI_ResponsibleParty>
+         <gmd:individualName>
+            <gco:CharacterString>Brown,Teresa Jane</gco:CharacterString>
+         </gmd:individualName>
+         <gmd:organisationName>
+            <gco:CharacterString>British Geological Survey</gco:CharacterString>
+         </gmd:organisationName>
+         <gmd:positionName>
+            <gco:CharacterString>NERC-BGS Mineral Commodity Geologist</gco:CharacterString>
+         </gmd:positionName>
+         <gmd:contactInfo>
+            <gmd:CI_Contact>
+               <gmd:phone>
+                  <gmd:CI_Telephone>
+                     <gmd:voice>
+                        <gco:CharacterString>+44 115 936 3100 Ex:3499</gco:CharacterString>
+                     </gmd:voice>
+                  </gmd:CI_Telephone>
+               </gmd:phone>
+               <gmd:address>
+                  <gmd:CI_Address>
+                     <gmd:deliveryPoint>
+                        <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                     </gmd:deliveryPoint>
+                     <gmd:city>
+                        <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                     </gmd:city>
+                     <gmd:administrativeArea>
+                        <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                     </gmd:administrativeArea>
+                     <gmd:postalCode>
+                        <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                     </gmd:postalCode>
+                     <gmd:country>
+                        <gco:CharacterString>United Kingdom</gco:CharacterString>
+                     </gmd:country>
+                     <gmd:electronicMailAddress>
+                        <gco:CharacterString>tbrown@bgs.ac.uk</gco:CharacterString>
+                     </gmd:electronicMailAddress>
+                  </gmd:CI_Address>
+               </gmd:address>
+            </gmd:CI_Contact>
+         </gmd:contactInfo>
+         <gmd:role>
+            <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+         </gmd:role>
+      </gmd:CI_ResponsibleParty>
+   </gmd:contact>
+   <gmd:dateStamp>
+      <gco:Date>2017-06-21</gco:Date>
+   </gmd:dateStamp>
+   <gmd:metadataStandardName>
+      <gco:CharacterString>NERC profile of ISO19115:2003</gco:CharacterString>
+   </gmd:metadataStandardName>
+   <gmd:metadataStandardVersion>
+      <gco:CharacterString>1.0</gco:CharacterString>
+   </gmd:metadataStandardVersion>
+   <gmd:dataSetURI>
+      <gmx:Anchor xlink:href="http://data.bgs.ac.uk/id/dataHolding/13480180">some data set</gmx:Anchor>
+      <!--<gco:CharacterString>http://data.bgs.ac.uk/id/dataHolding/13480180</gco:CharacterString>-->
+   </gmd:dataSetURI>
+   <!-- C.7.2 Spatial Representation Information [EL] for ds/dss-->
+   <gmd:spatialRepresentationInfo>
+      <gmd:MD_Georectified>
+         <gmd:numberOfDimensions/>
+         <gmd:cellGeometry/>
+         <gmd:transformationParameterAvailability/>
+         <gmd:checkPointAvailability/>
+         <gmd:pointInPixel/>
+      </gmd:MD_Georectified>
+   </gmd:spatialRepresentationInfo>
+   <gmd:spatialRepresentationInfo>
+      <gmd:MD_Georeferenceable>
+         <gmd:numberOfDimensions/>
+         <gmd:cellGeometry/>
+         <gmd:transformationParameterAvailability/>
+         <gmd:controlPointAvailability/>
+         <gmd:orientationParameterAvailability/>
+         <gmd:georeferencedParameters/>
+      </gmd:MD_Georeferenceable>
+   </gmd:spatialRepresentationInfo>
+   <gmd:spatialRepresentationInfo>
+      <gmd:MD_GridSpatialRepresentation>
+         <gmd:numberOfDimensions/>
+         <gmd:cellGeometry/>
+         <gmd:transformationParameterAvailability/>
+      </gmd:MD_GridSpatialRepresentation>
+   </gmd:spatialRepresentationInfo>
+   <gmd:spatialRepresentationInfo>
+      <gmd:MD_VectorSpatialRepresentation>
+         <gmd:geometricObjects>
+            <gmd:MD_GeometricObjects>
+               <gmd:geometricObjectType/>
+            </gmd:MD_GeometricObjects>
+         </gmd:geometricObjects>
+      </gmd:MD_VectorSpatialRepresentation>
+   </gmd:spatialRepresentationInfo>
+   <gmd:referenceSystemInfo>
+      <gmd:MD_ReferenceSystem>
+         <gmd:referenceSystemIdentifier>
+            <gmd:RS_Identifier>
+               <gmd:code>
+                  <gco:CharacterString>http://www.opengis.net/def/crs/EPSG/0/3044</gco:CharacterString>
+               </gmd:code>
+            </gmd:RS_Identifier>
+         </gmd:referenceSystemIdentifier>
+      </gmd:MD_ReferenceSystem>
+   </gmd:referenceSystemInfo>
+   <gmd:referenceSystemInfo>
+      <gmd:MD_ReferenceSystem>
+         <gmd:referenceSystemIdentifier>
+            <gmd:RS_Identifier>
+               <gmd:code>
+                  <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/27700">British National Grid</gmx:Anchor>
+               </gmd:code>
+               <gmd:codeSpace>
+                  <gco:CharacterString>some such text</gco:CharacterString>
+               </gmd:codeSpace>
+            </gmd:RS_Identifier>
+         </gmd:referenceSystemIdentifier>
+      </gmd:MD_ReferenceSystem>
+   </gmd:referenceSystemInfo>
+   <gmd:identificationInfo>
+      <gmd:MD_DataIdentification id="BGS-13480180">
+         <gmd:citation>
+            <gmd:CI_Citation>
+               <gmd:title>
+                  <gco:CharacterString>World Mineral Statistics Dataset</gco:CharacterString>
+               </gmd:title>
+               <gmd:alternateTitle>
+                  <gmx:Anchor xlink:href="https://www.loc.gov/standards/iso639-2/php/langcodes_name.php?code_ID=487">Set Ddata Ystadegau Mwynau y Byd</gmx:Anchor>
+               </gmd:alternateTitle>
+               <gmd:date>
+                  <gmd:CI_Date>
+                     <gmd:date>
+                        <gco:Date>1918</gco:Date>
+                     </gmd:date>
+                     <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                     </gmd:dateType>
+                  </gmd:CI_Date>
+               </gmd:date>
+               <gmd:identifier>
+                  <gmd:MD_Identifier>
+                     <gmd:code>
+                        <gmx:Anchor xlink:href="http://data.bgs.ac.uk/id/dataHolding/13480180">World Mineral Statistics Dataset</gmx:Anchor>
+                     </gmd:code>
+                  </gmd:MD_Identifier>
+               </gmd:identifier>
+               <gmd:identifier>
+                  <gmd:RS_Identifier>
+                     <gmd:code>
+                        <gco:CharacterString>10.5285/1e7d5e08-9e24-471b-ae37-49b477f695e3</gco:CharacterString>
+                     </gmd:code>
+                     <gmd:codeSpace>
+                        <gmx:Anchor xlink:href="https://www.doi.org/" xlink:title="Digital Object Identifier (DOI)">doi</gmx:Anchor>
+                     </gmd:codeSpace>
+                  </gmd:RS_Identifier>
+               </gmd:identifier>
+            </gmd:CI_Citation>
+         </gmd:citation>
+         <gmd:abstract>
+            <gco:CharacterString>The British Geological Survey has one of the largest databases in the world on the production and trade of minerals. 
+             The dataset contains annual production statistics by mass for more than 70 mineral commodities covering the majority of economically important 
+             and internationally-traded minerals, metals and mineral-based materials. For each commodity the annual production statistics are recorded for 
+             individual countries, grouped by continent. Import and export statistics are also available for years up to 2002. Maintenance of the database 
+             is funded by the Science Budget and output is used by government, private industry and others in support of policy, economic analysis and 
+             commercial strategy. As far as possible the production data are compiled from primary, official sources. Quality assurance is maintained by 
+             participation in such groups as the International Consultative Group on Non-ferrous Metal Statistics. Individual commodity and country tables 
+             are available for sale on request.</gco:CharacterString>
+         </gmd:abstract>
+         <gmd:pointOfContact>
+            <gmd:CI_ResponsibleParty>
+               <gmd:organisationName>
+                  <gco:CharacterString>British Geological Survey</gco:CharacterString>
+               </gmd:organisationName>
+               <gmd:contactInfo>
+                  <gmd:CI_Contact>
+                     <gmd:phone>
+                        <gmd:CI_Telephone>
+                           <gmd:voice>
+                              <gco:CharacterString>+44 115 936 3143</gco:CharacterString>
+                           </gmd:voice>
+                           <gmd:facsimile>
+                              <gco:CharacterString>+44 115 936 3276</gco:CharacterString>
+                           </gmd:facsimile>
+                        </gmd:CI_Telephone>
+                     </gmd:phone>
+                     <gmd:address>
+                        <gmd:CI_Address>
+                           <gmd:deliveryPoint>
+                              <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                           </gmd:deliveryPoint>
+                           <gmd:city>
+                              <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                           </gmd:city>
+                           <gmd:administrativeArea>
+                              <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                           </gmd:administrativeArea>
+                           <gmd:postalCode>
+                              <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                           </gmd:postalCode>
+                           <gmd:country>
+                              <gco:CharacterString>United Kingdom</gco:CharacterString>
+                           </gmd:country>
+                           <gmd:electronicMailAddress>
+                              <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                           </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                     </gmd:address>
+                  </gmd:CI_Contact>
+               </gmd:contactInfo>
+               <gmd:role>
+                  <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+               </gmd:role>
+            </gmd:CI_ResponsibleParty>
+         </gmd:pointOfContact>
+         <gmd:pointOfContact>
+            <gmd:CI_ResponsibleParty>
+               <gmd:organisationName>
+                  <gco:CharacterString>British Geological Survey</gco:CharacterString>
+               </gmd:organisationName>
+               <gmd:contactInfo>
+                  <gmd:CI_Contact>
+                     <gmd:phone>
+                        <gmd:CI_Telephone>
+                           <gmd:voice>
+                              <gco:CharacterString>+44 115 936 3100 Ex:3112</gco:CharacterString>
+                           </gmd:voice>
+                        </gmd:CI_Telephone>
+                     </gmd:phone>
+                     <gmd:address>
+                        <gmd:CI_Address>
+                           <gmd:deliveryPoint>
+                              <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                           </gmd:deliveryPoint>
+                           <gmd:city>
+                              <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                           </gmd:city>
+                           <gmd:administrativeArea>
+                              <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                           </gmd:administrativeArea>
+                           <gmd:postalCode>
+                              <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                           </gmd:postalCode>
+                           <gmd:country>
+                              <gco:CharacterString>United Kingdom</gco:CharacterString>
+                           </gmd:country>
+                           <gmd:electronicMailAddress>
+                              <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                           </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                     </gmd:address>
+                  </gmd:CI_Contact>
+               </gmd:contactInfo>
+               <gmd:role>
+                  <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="originator">originator</gmd:CI_RoleCode>
+               </gmd:role>
+            </gmd:CI_ResponsibleParty>
+         </gmd:pointOfContact>
+         <gmd:pointOfContact>
+            <gmd:CI_ResponsibleParty>
+               <gmd:organisationName>
+                  <gco:CharacterString>British Geological Survey</gco:CharacterString>
+               </gmd:organisationName>
+               <gmd:contactInfo>
+                  <gmd:CI_Contact>
+                     <gmd:phone>
+                        <gmd:CI_Telephone>
+                           <gmd:voice>
+                              <gco:CharacterString>+44 115 936 3100 Ex:4193</gco:CharacterString>
+                           </gmd:voice>
+                        </gmd:CI_Telephone>
+                     </gmd:phone>
+                     <gmd:address>
+                        <gmd:CI_Address>
+                           <gmd:deliveryPoint>
+                              <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                           </gmd:deliveryPoint>
+                           <gmd:city>
+                              <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                           </gmd:city>
+                           <gmd:administrativeArea>
+                              <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                           </gmd:administrativeArea>
+                           <gmd:postalCode>
+                              <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                           </gmd:postalCode>
+                           <gmd:country>
+                              <gco:CharacterString>United Kingdom</gco:CharacterString>
+                           </gmd:country>
+                           <gmd:electronicMailAddress>
+                              <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                           </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                     </gmd:address>
+                  </gmd:CI_Contact>
+               </gmd:contactInfo>
+               <gmd:role>
+                  <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+               </gmd:role>
+            </gmd:CI_ResponsibleParty>
+         </gmd:pointOfContact>
+         <gmd:pointOfContact>
+            <gmd:CI_ResponsibleParty>
+               <gmd:organisationName>
+                  <gco:CharacterString>British Geological Survey</gco:CharacterString>
+               </gmd:organisationName>
+               <gmd:contactInfo>
+                  <gmd:CI_Contact>
+                     <gmd:phone>
+                        <gmd:CI_Telephone>
+                           <gmd:voice>
+                              <gco:CharacterString>+44 115 936 3100 Ex:3499</gco:CharacterString>
+                           </gmd:voice>
+                        </gmd:CI_Telephone>
+                     </gmd:phone>
+                     <gmd:address>
+                        <gmd:CI_Address>
+                           <gmd:deliveryPoint>
+                              <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                           </gmd:deliveryPoint>
+                           <gmd:city>
+                              <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                           </gmd:city>
+                           <gmd:administrativeArea>
+                              <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                           </gmd:administrativeArea>
+                           <gmd:postalCode>
+                              <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                           </gmd:postalCode>
+                           <gmd:country>
+                              <gco:CharacterString>United Kingdom</gco:CharacterString>
+                           </gmd:country>
+                           <gmd:electronicMailAddress>
+                              <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                           </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                     </gmd:address>
+                  </gmd:CI_Contact>
+               </gmd:contactInfo>
+               <gmd:role>
+                  <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+               </gmd:role>
+            </gmd:CI_ResponsibleParty>
+         </gmd:pointOfContact>
+         <!-- C.7.1 Maintenance Information for ds/dss not sv -->
+         <gmd:resourceMaintenance>
+            <gmd:MD_MaintenanceInformation>
+               <!-- At least maintenanceAndUpdateFrequency should be used -->
+               <gmd:maintenanceAndUpdateFrequency>
+                  <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="annually">annually</gmd:MD_MaintenanceFrequencyCode>
+               </gmd:maintenanceAndUpdateFrequency>
+               <!-- The following elements are recommended-->
+               <gmd:updateScope>
+                  <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset"/>
+               </gmd:updateScope>
+               <gmd:maintenanceNote>
+                  <gco:CharacterString>[Information regarding specific requirements for maintaining the resource]</gco:CharacterString>
+               </gmd:maintenanceNote>
+            </gmd:MD_MaintenanceInformation>
+         </gmd:resourceMaintenance>
+         <!--C 7.6 Browse graphic information [EL and OI] for ds/dss not sv -->
+         <gmd:graphicOverview>
+            <gmd:MD_BrowseGraphic>
+               <gmd:fileName/>
+            </gmd:MD_BrowseGraphic>
+         </gmd:graphicOverview>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/concept?cp=13&amp;langcode=en&amp;ns=5" xlink:title="Geology">Geology</gmx:Anchor>
+               </gmd:keyword>
+               <gmd:thesaurusName>
+                  <gmd:CI_Citation>
+                     <gmd:title>
+                        <gco:CharacterString>GEMET - INSPIRE themes</gco:CharacterString>
+                     </gmd:title>
+                     <gmd:date>
+                        <gmd:CI_Date>
+                           <gmd:date>
+                              <gco:Date>2008-06-01</gco:Date>
+                           </gmd:date>
+                           <gmd:dateType>
+                              <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                           </gmd:dateType>
+                        </gmd:CI_Date>
+                     </gmd:date>
+                  </gmd:CI_Citation>
+               </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gco:CharacterString>Statistics</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Exports</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Ores</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Mineral economics</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Imports</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Commerce</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Mineral statistics</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Commodity economics</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Production</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:thesaurusName>
+                  <gmd:CI_Citation>
+                     <gmd:title>
+                        <gco:CharacterString>BGS Thesaurus of Geosciences</gco:CharacterString>
+                     </gmd:title>
+                     <gmd:date>
+                        <gmd:CI_Date>
+                           <gmd:date>
+                              <gco:Date>2011</gco:Date>
+                           </gmd:date>
+                           <gmd:dateType>
+                              <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                           </gmd:dateType>
+                        </gmd:CI_Date>
+                     </gmd:date>
+                  </gmd:CI_Citation>
+               </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gco:CharacterString>NERC_DDC</gco:CharacterString>
+               </gmd:keyword>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <!-- At least two gmd:resourceConstraints sections are expected here…  -->
+         <gmd:resourceConstraints xlink:title="Limitations">
+            <gmd:MD_LegalConstraints>
+               <gmd:accessConstraints>
+                  <gmd:MD_RestrictionCode codeList="gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+               </gmd:accessConstraints>
+               <gmd:otherConstraints>
+                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/INSPIRE_Directive_Article13_1z">otherRestrictions</gmx:Anchor>
+               </gmd:otherConstraints>
+            </gmd:MD_LegalConstraints>
+         </gmd:resourceConstraints>
+         <gmd:resourceConstraints xlink:title="Conditions">
+            <gmd:MD_LegalConstraints>
+               <gmd:useConstraints>
+                  <gmd:MD_RestrictionCode codeList="gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+               </gmd:useConstraints>
+               <gmd:otherConstraints>
+                  <gmx:Anchor xlink:href="#">Conditions apply</gmx:Anchor>
+               </gmd:otherConstraints>
+            </gmd:MD_LegalConstraints>
+         </gmd:resourceConstraints>
+         <gmd:spatialRepresentationType>
+            <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="textTable"/>
+         </gmd:spatialRepresentationType>
+         <gmd:spatialResolution>
+            <gmd:MD_Resolution>
+               <gmd:equivalentScale/>
+            </gmd:MD_Resolution>
+         </gmd:spatialResolution>
+         <gmd:language>
+            <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/php/code_list.php" codeListValue="eng">English</gmd:LanguageCode>
+         </gmd:language>
+         <gmd:characterSet>
+            <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="8859part1">ISO/IEC 8859-1 (also known as Latin 1)</gmd:MD_CharacterSetCode>
+         </gmd:characterSet>
+         <gmd:topicCategory>
+            <gmd:MD_TopicCategoryCode>geoscientificInformation</gmd:MD_TopicCategoryCode>
+         </gmd:topicCategory>
+         <!-- C.7.10 Extent, already covered by GEMINI, for ds/dss -->
+         <gmd:extent>
+            <gmd:EX_Extent>
+               <gmd:geographicElement>
+                  <gmd:EX_GeographicDescription>
+                     <gmd:geographicIdentifier>
+                        <gmd:MD_Identifier>
+                           <gmd:authority>
+                              <gmd:CI_Citation>
+                                 <gmd:title>
+                                    <gco:CharacterString>British Geological Survey Gazetteer: Geographical hierarchy from Geosaurus</gco:CharacterString>
+                                 </gmd:title>
+                                 <gmd:date>
+                                    <gmd:CI_Date>
+                                       <gmd:date>
+                                          <gco:Date>1979</gco:Date>
+                                       </gmd:date>
+                                       <gmd:dateType>
+                                          <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                       </gmd:dateType>
+                                    </gmd:CI_Date>
+                                 </gmd:date>
+                              </gmd:CI_Citation>
+                           </gmd:authority>
+                           <gmd:code>
+                              <gco:CharacterString>WORLD [id=100000]</gco:CharacterString>
+                           </gmd:code>
+                        </gmd:MD_Identifier>
+                     </gmd:geographicIdentifier>
+                  </gmd:EX_GeographicDescription>
+               </gmd:geographicElement>
+               <gmd:geographicElement>
+                  <gmd:EX_GeographicBoundingBox>
+                     <gmd:westBoundLongitude>
+                        <gco:Decimal>-180.0000</gco:Decimal>
+                     </gmd:westBoundLongitude>
+                     <gmd:eastBoundLongitude>
+                        <gco:Decimal>180.0000</gco:Decimal>
+                     </gmd:eastBoundLongitude>
+                     <gmd:southBoundLatitude>
+                        <gco:Decimal>-90.0000</gco:Decimal>
+                     </gmd:southBoundLatitude>
+                     <gmd:northBoundLatitude>
+                        <gco:Decimal>90.0000</gco:Decimal>
+                     </gmd:northBoundLatitude>
+                  </gmd:EX_GeographicBoundingBox>
+               </gmd:geographicElement>
+               <gmd:temporalElement gco:nilReason="missing"/>
+               <gmd:verticalElement>
+                  <gmd:EX_VerticalExtent>
+                     <gmd:minimumValue gco:nilReason="missing"/>
+                     <gmd:maximumValue gco:nilReason="missing"/>
+                     <gmd:verticalCRS/>
+                  </gmd:EX_VerticalExtent>
+               </gmd:verticalElement>
+            </gmd:EX_Extent>
+         </gmd:extent>
+         <!-- C.7.3 Supplemental Information(already covered by GEMINI additional information) for ds/dss -->
+         <gmd:supplementalInformation>
+            <gco:CharacterString>Update of individual annual figures is a year-round process. 'World Mineral Statistics 1997-2001'(annual) BGS PUBLICATION. PUBLICATION: 'WORLD MINERAL STATISTICS 1995-99' Mackenzie, A.C. et al. 1999 PUBLICATION: MODERNISATION OF THE WORLD MINERALS STATISTICS DATABASE, BGS TECHNICAL REPORT. 'World Mineral Statistics 1998-2002' 'European Mineral Statistics 1997-2001' 'European Mineral Statistics 1998-2002' Additional data on trade are available in paper form (sources of imports, destinations of exports). No data are routinely compiled on aggregate minerals (crushed rock or natural). For 12 commodities data are for production only. Standard abbreviations and symbols are used throughout. Units of measurements are tonnes, kilograms or carats, according to commodity. Value (#) is used where mass is not available. Estimated numbers are rounded to between one and three orders of magnitude higher than the measured totals.</gco:CharacterString>
+         </gmd:supplementalInformation>
+      </gmd:MD_DataIdentification>
+   </gmd:identificationInfo>
+   <!-- C.7.7 Image description [OI] for ds/dss na sv -->
+   <gmd:contentInfo>
+      <gmd:MD_ImageDescription>
+         <gmd:attributeDescription/>
+         <gmd:contentType/>
+      </gmd:MD_ImageDescription>
+   </gmd:contentInfo>
+   <!-- C.7.8 Content Information [BU] for ds/dss na sv -->
+   <gmd:contentInfo>
+      <gmd:MD_FeatureCatalogueDescription>
+         <gmd:includedWithDataset>
+            <gco:Boolean>false</gco:Boolean>
+         </gmd:includedWithDataset>
+         <gmd:featureCatalogueCitation>
+            <gmd:CI_Citation>
+               <gmd:title/>
+               <gmd:date/>
+            </gmd:CI_Citation>
+         </gmd:featureCatalogueCitation>
+      </gmd:MD_FeatureCatalogueDescription>
+   </gmd:contentInfo>
+   <gmd:distributionInfo>
+      <gmd:MD_Distribution>
+         <gmd:distributionFormat>
+            <gmd:MD_Format>
+               <gmd:name>
+                  <gco:CharacterString>BOOKS - From 1913 to 1997 (data years) as annual books, or photocopies of parts thereof. Each book covers a 5-year run of statistics.</gco:CharacterString>
+               </gmd:name>
+               <gmd:version gco:nilReason="unknown"/>
+            </gmd:MD_Format>
+         </gmd:distributionFormat>
+         <gmd:distributionFormat>
+            <gmd:MD_Format>
+               <gmd:name>
+                  <gco:CharacterString>PAPER</gco:CharacterString>
+               </gmd:name>
+               <gmd:version gco:nilReason="unknown"/>
+            </gmd:MD_Format>
+         </gmd:distributionFormat>
+         <gmd:distributionFormat>
+            <gmd:MD_Format>
+               <gmd:name>
+                  <gco:CharacterString>.TXT FILES - From 1985 to 1992 (data years) individual commodity tables can also be presented as .txt files, or edited to formatted text or MS-Word files.</gco:CharacterString>
+               </gmd:name>
+               <gmd:version gco:nilReason="unknown"/>
+            </gmd:MD_Format>
+         </gmd:distributionFormat>
+         <gmd:distributionFormat>
+            <gmd:MD_Format>
+               <gmd:name>
+                  <gco:CharacterString>MS WORD - Form 1990 to 1997 (data years) individual tables can be presented as MS-Word files by commodity or country.</gco:CharacterString>
+               </gmd:name>
+               <gmd:version gco:nilReason="unknown"/>
+            </gmd:MD_Format>
+         </gmd:distributionFormat>
+         <gmd:distributionFormat>
+            <gmd:MD_Format>
+               <gmd:name>
+                  <gco:CharacterString>PDF FILES</gco:CharacterString>
+               </gmd:name>
+               <gmd:version gco:nilReason="unknown"/>
+            </gmd:MD_Format>
+         </gmd:distributionFormat>
+         <gmd:distributor>
+            <gmd:MD_Distributor>
+               <gmd:distributorContact>
+                  <gmd:CI_ResponsibleParty>
+                     <gmd:organisationName>
+                        <gco:CharacterString>British Geological Survey</gco:CharacterString>
+                     </gmd:organisationName>
+                     <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                           <gmd:phone>
+                              <gmd:CI_Telephone>
+                                 <gmd:voice>
+                                    <gco:CharacterString>+44 115 936 3143</gco:CharacterString>
+                                 </gmd:voice>
+                                 <gmd:facsimile>
+                                    <gco:CharacterString>+44 115 936 3276</gco:CharacterString>
+                                 </gmd:facsimile>
+                              </gmd:CI_Telephone>
+                           </gmd:phone>
+                           <gmd:address>
+                              <gmd:CI_Address>
+                                 <gmd:deliveryPoint>
+                                    <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                                 </gmd:deliveryPoint>
+                                 <gmd:city>
+                                    <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                                 </gmd:city>
+                                 <gmd:administrativeArea>
+                                    <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                                 </gmd:administrativeArea>
+                                 <gmd:postalCode>
+                                    <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                                 </gmd:postalCode>
+                                 <gmd:country>
+                                    <gco:CharacterString>United Kingdom</gco:CharacterString>
+                                 </gmd:country>
+                                 <gmd:electronicMailAddress>
+                                    <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                                 </gmd:electronicMailAddress>
+                              </gmd:CI_Address>
+                           </gmd:address>
+                        </gmd:CI_Contact>
+                     </gmd:contactInfo>
+                     <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+                     </gmd:role>
+                  </gmd:CI_ResponsibleParty>
+               </gmd:distributorContact>
+            </gmd:MD_Distributor>
+         </gmd:distributor>
+         <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+               <!-- C7.9 [EL and OI] for ds/dss -->
+               <gmd:unitsOfDistribution/>
+               <!-- C7.9 [HY] for ds/dss -->
+               <gmd:transferSize>
+                  <gco:Real>10000000000</gco:Real>
+               </gmd:transferSize>
+               <gmd:onLine>
+                  <gmd:CI_OnlineResource>
+                     <gmd:linkage>
+                        <gmd:URL>http://www.bgs.ac.uk/mineralsuk/statistics/worldStatistics.html</gmd:URL>
+                     </gmd:linkage>
+                     <gmd:name>
+                        <gco:CharacterString>BGS (Minerals UK) World Mineral Statistics</gco:CharacterString>
+                     </gmd:name>
+                     <gmd:description>
+                        <gco:CharacterString>Home page for BGS World Mineral Statistics</gco:CharacterString>
+                     </gmd:description>
+                     <gmd:function>
+                        <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information"/>
+                     </gmd:function>
+                  </gmd:CI_OnlineResource>
+               </gmd:onLine>
+               <!-- C7.9 [EL and OI] for ds/dss -->
+               <gmd:offLine>
+                  <gmd:MD_Medium>
+                     <gmd:mediumFormat> </gmd:mediumFormat>
+                  </gmd:MD_Medium>
+               </gmd:offLine>
+            </gmd:MD_DigitalTransferOptions>
+         </gmd:transferOptions>
+      </gmd:MD_Distribution>
+   </gmd:distributionInfo>
+   <gmd:dataQualityInfo>
+      <gmd:DQ_DataQuality>
+         <gmd:scope>
+            <gmd:DQ_Scope>
+               <gmd:level>
+                  <gmd:MD_ScopeCode codeList="gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+               </gmd:level>
+            </gmd:DQ_Scope>
+         </gmd:scope>
+         <gmd:report>
+            <gmd:DQ_DomainConsistency>
+               <gmd:result>
+                  <gmd:DQ_ConformanceResult>
+                     <gmd:specification>
+                        <gmd:CI_Citation>
+                           <gmd:title>
+                              <gco:CharacterString>INSPIRE Implementing rules laying down technical arrangements for the interoperability and harmonisation of Geology</gco:CharacterString>
+                           </gmd:title>
+                           <gmd:date>
+                              <gmd:CI_Date>
+                                 <gmd:date>
+                                    <gco:Date>2011</gco:Date>
+                                 </gmd:date>
+                                 <gmd:dateType>
+                                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                 </gmd:dateType>
+                              </gmd:CI_Date>
+                           </gmd:date>
+                        </gmd:CI_Citation>
+                     </gmd:specification>
+                     <gmd:explanation>
+                        <gco:CharacterString>See the referenced specification</gco:CharacterString>
+                     </gmd:explanation>
+                     <gmd:pass>
+                        <gco:Boolean>false</gco:Boolean>
+                     </gmd:pass>
+                  </gmd:DQ_ConformanceResult>
+               </gmd:result>
+            </gmd:DQ_DomainConsistency>
+         </gmd:report>
+         <gmd:report>
+            <gmd:DQ_DomainConsistency>
+               <gmd:result>
+                  <gmd:DQ_ConformanceResult>
+                     <gmd:specification>
+                        <gmd:CI_Citation>
+                           <gmd:title>
+                              <gmx:Anchor xlink:href="http://data.europa.eu/eli/reg/2010/1089">Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services</gmx:Anchor>
+                           </gmd:title>
+                           <gmd:date>
+                              <gmd:CI_Date>
+                                 <gmd:date>
+                                    <gco:Date>2010-12-08</gco:Date>
+                                 </gmd:date>
+                                 <gmd:dateType>
+                                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
+                                 </gmd:dateType>
+                              </gmd:CI_Date>
+                           </gmd:date>
+                        </gmd:CI_Citation>
+                     </gmd:specification>
+                     <!-- Explanation is a required element but can be empty -->
+                     <gmd:explanation gco:nilReason="inapplicable"/>
+                     <!-- 
+                     <gmd:explanation>
+                        <gco:CharacterString>TG Requirement C.22: metadata/2.0/req/common/conformity-degree states that: Each gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult element containing a specification citation described in Requirement C.21 shall also include the degree of declared conformity against this specification using gmd:pass property with gco:Boolean value of "true" for a conformant</gco:CharacterString>
+                     </gmd:explanation>
+                      -->
+                     <!-- If the conformance failed then 
+                     <gmd:pass>
+                        <gco:Boolean>false</gco:Boolean>
+                     </gmd:pass> -->
+                     <!-- If not tested then -->
+                     <gmd:pass gco:nilReason="unknown"/>
+                  </gmd:DQ_ConformanceResult>
+               </gmd:result>
+            </gmd:DQ_DomainConsistency>
+         </gmd:report>
+         <gmd:report>
+            <gmd:DQ_TopologicalConsistency>
+               <gmd:nameOfMeasure>
+                  <gco:CharacterString>
+                     Number of faulty point-curve connections
+                  </gco:CharacterString>
+               </gmd:nameOfMeasure>
+               <gmd:evaluationMethodType>
+                  <gmd:DQ_EvaluationMethodTypeCode codeList="standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#DQ_EvaluationMethodTypeCode" codeListValue="indirect"/>
+               </gmd:evaluationMethodType>
+               <gmd:evaluationMethodDescription>
+                  <gco:CharacterString>
+                     A point-curve connection exists where different curves touch... 
+                  </gco:CharacterString>
+               </gmd:evaluationMethodDescription>
+               <gmd:dateTime/>
+               <gmd:result>
+                  <gmd:DQ_QuantitativeResult>
+                     <!--The mandatory elements are valueUnit and value/Record with xsi:type -->
+                     <gmd:valueUnit xlink:href="http://www.opengis.net/def/uom/OGC/1.0/unity"/>
+                     <gmd:value>
+                        <gco:Record xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xsi:type="xs:integer">12</gco:Record>
+                     </gmd:value>
+                  </gmd:DQ_QuantitativeResult>
+               </gmd:result>
+            </gmd:DQ_TopologicalConsistency>
+         </gmd:report>
+         <gmd:report>
+            <gmd:DQ_TopologicalConsistency>
+               <gmd:result>
+                  <gmd:DQ_ConformanceResult>
+                     <gmd:specification>
+                        <gmd:CI_Citation>
+                           <gmd:title>
+                              <!-- The title for this report shall always be "INSPIRE Data Specifications - Base Models - Generic Network Model" -->
+                              <gco:CharacterString>INSPIRE Data Specifications - Base Models - Generic Network Model</gco:CharacterString>
+                           </gmd:title>
+                           <gmd:date>
+                              <gmd:CI_Date>
+                                 <gmd:date>
+                                    <!-- The date shall be the date of publication of the Generic Network Model -->
+                                    <gco:Date>2013-04-05</gco:Date>
+                                 </gmd:date>
+                                 <gmd:dateType>
+                                    <!-- The code list value shall always be publication -->
+                                    <gmd:CI_DateTypeCode codeList="" codeListValue="publication"/>
+                                 </gmd:dateType>
+                              </gmd:CI_Date>
+                           </gmd:date>
+                        </gmd:CI_Citation>
+                     </gmd:specification>
+                     <!-- An explanation must be provided-->
+                     <gmd:explanation>
+                        <gco:CharacterString>[Some statement on topological consistency]</gco:CharacterString>
+                     </gmd:explanation>
+                     <gmd:pass>
+                        <!-- The value shall always be false to indicate that the data does not assure the centerline topology for the network -->
+                        <gco:Boolean>false</gco:Boolean>
+                     </gmd:pass>
+                  </gmd:DQ_ConformanceResult>
+               </gmd:result>
+            </gmd:DQ_TopologicalConsistency>
+         </gmd:report>
+         <!-- C.7.11 Data Quality for ds and dss (N/A for sv) -->
+         <gmd:report>
+            <gmd:DQ_DomainConsistency>
+               <gmd:measureDescription gco:nilReason="unknown"/>
+               <gmd:result>
+                  <gmd:DQ_QuantitativeResult>
+                     <gmd:valueUnit/>
+                     <gmd:value/>
+                  </gmd:DQ_QuantitativeResult>
+               </gmd:result>
+            </gmd:DQ_DomainConsistency>
+         </gmd:report>
+         <gmd:lineage>
+            <gmd:LI_Lineage>
+               <gmd:statement>
+                  <gco:CharacterString>The dataset has been compiled continuously since the year 1918 (statistics from 1913).</gco:CharacterString>
+               </gmd:statement>
+               <!-- C 7.4 Process Step [ELevation and OrthoImagery] for ds and dss N/A for sv -->
+               <gmd:processStep>
+                  <gmd:LI_ProcessStep>
+                     <gmd:description/>
+                  </gmd:LI_ProcessStep>
+               </gmd:processStep>
+               <!-- C 7.5 Data source [ELevation and OrthoImagery] for ds and dss N/A for sv -->
+               <gmd:source>
+                  <gmd:LI_Source> </gmd:LI_Source>
+               </gmd:source>
+            </gmd:LI_Lineage>
+         </gmd:lineage>
+      </gmd:DQ_DataQuality>
+   </gmd:dataQualityInfo>
+   <gmd:dataQualityInfo>
+      <gmd:DQ_DataQuality>
+         <gmd:scope>
+            <gmd:DQ_Scope>
+               <gmd:level>
+                  <gmd:MD_ScopeCode codeList="gmxCodelists.xml#MD_ScopeCode" codeListValue="attribute">some attribute</gmd:MD_ScopeCode>
+               </gmd:level>
+            </gmd:DQ_Scope>
+         </gmd:scope>
+      </gmd:DQ_DataQuality>
+   </gmd:dataQualityInfo>
+</gmd:MD_Metadata>

--- a/ckanext/spatial/tests/xml/gemini2.3/validation/BGSsv-examplea1.xml
+++ b/ckanext/spatial/tests/xml/gemini2.3/validation/BGSsv-examplea1.xml
@@ -1,0 +1,857 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gsr="http://www.isotc211.org/2005/gsr"
+    xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts"
+    xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:geonet="http://www.fao.org/geonetwork"
+    xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://inspire.ec.europa.eu/draft-schemas/inspire-md-schemas/apiso-inspire/apiso-inspire.xsd">
+    <gmd:fileIdentifier>
+        <gco:CharacterString>ea819b92-d389-193a-e044-002128a47908</gco:CharacterString>
+    </gmd:fileIdentifier>
+    <gmd:language>
+        <gmd:LanguageCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#LanguageCode" codeListValue="eng">English</gmd:LanguageCode>
+    </gmd:language>
+    <gmd:parentIdentifier gco:nilReason="inapplicable"/>
+    <gmd:hierarchyLevel>
+        <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="service">service</gmd:MD_ScopeCode>
+    </gmd:hierarchyLevel>
+    <gmd:hierarchyLevelName>
+        <gmx:Anchor>service</gmx:Anchor>
+    </gmd:hierarchyLevelName>
+    <gmd:contact>
+        <gmd:CI_ResponsibleParty>
+            <gmd:individualName>
+                <gco:CharacterString>Bell,Patrick D</gco:CharacterString>
+            </gmd:individualName>
+            <gmd:organisationName>
+                <gco:CharacterString>British Geological Survey</gco:CharacterString>
+            </gmd:organisationName>
+            <gmd:positionName>
+                <gco:CharacterString>NERC-BGS TL Web Systems</gco:CharacterString>
+            </gmd:positionName>
+            <gmd:contactInfo>
+                <gmd:CI_Contact>
+                    <gmd:phone>
+                        <gmd:CI_Telephone>
+                            <gmd:voice>
+                                <gco:CharacterString>+44 115 936 3100 Ex:3075</gco:CharacterString>
+                            </gmd:voice>
+                        </gmd:CI_Telephone>
+                    </gmd:phone>
+                    <gmd:address>
+                        <gmd:CI_Address>
+                            <gmd:deliveryPoint>
+                                <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                            </gmd:deliveryPoint>
+                            <gmd:city>
+                                <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                            </gmd:city>
+                            <gmd:administrativeArea>
+                                <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                            </gmd:administrativeArea>
+                            <gmd:postalCode>
+                                <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                            </gmd:postalCode>
+                            <gmd:country>
+                                <gco:CharacterString>United Kingdom</gco:CharacterString>
+                            </gmd:country>
+                            <gmd:electronicMailAddress>
+                                <gco:CharacterString>pdbe@bgs.ac.uk</gco:CharacterString>
+                            </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                    </gmd:address>
+                </gmd:CI_Contact>
+            </gmd:contactInfo>
+            <gmd:role>
+                <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+            </gmd:role>
+        </gmd:CI_ResponsibleParty>
+    </gmd:contact>
+    <gmd:dateStamp>
+        <gco:Date>2014-06-23</gco:Date>
+    </gmd:dateStamp>
+    <gmd:metadataStandardName>
+        <gco:CharacterString>NERC profile of ISO19115:2003</gco:CharacterString>
+    </gmd:metadataStandardName>
+    <gmd:metadataStandardVersion>
+        <gco:CharacterString>1.0</gco:CharacterString>
+    </gmd:metadataStandardVersion>
+    <gmd:dataSetURI>
+        <gco:CharacterString>http://data.bgs.ac.uk/id/dataHolding/13605835</gco:CharacterString>
+    </gmd:dataSetURI>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gco:CharacterString>urn:ogc:def:crs:EPSG::27700</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>OGP</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gco:CharacterString>urn:ogc:def:crs:EPSG::32631</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>OGP</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gco:CharacterString>urn:ogc:def:crs:EPSG::3857</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>OGP</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gco:CharacterString>urn:ogc:def:crs:EPSG::4258</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>OGP</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gco:CharacterString>urn:ogc:def:crs:EPSG::4326</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>OGP</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:identificationInfo>
+        <srv:SV_ServiceIdentification>
+            <gmd:citation>
+                <gmd:CI_Citation>
+                    <gmd:title>
+                        <gco:CharacterString>BGS GeoIndex - Offshore (cultural data) data theme (OGC WxS INSPIRE)</gco:CharacterString>
+                    </gmd:title>
+                    <gmd:alternateTitle>
+                        <gco:CharacterString>GIOFF...</gco:CharacterString>
+                    </gmd:alternateTitle>
+                    <gmd:date>
+                        <gmd:CI_Date>
+                            <gmd:date>
+                                <gco:Date>2013</gco:Date>
+                            </gmd:date>
+                            <gmd:dateType>
+                                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                            </gmd:dateType>
+                        </gmd:CI_Date>
+                    </gmd:date>
+                    <gmd:identifier>
+                        <gmd:MD_Identifier id="_1">
+                            <gmd:code>
+                                <gco:CharacterString>http://data.bgs.ac.uk/id/dataHolding/13605835</gco:CharacterString>
+                            </gmd:code>
+                        </gmd:MD_Identifier>
+                    </gmd:identifier>
+                </gmd:CI_Citation>
+            </gmd:citation>
+            <gmd:abstract>
+                <gco:CharacterString>Data from the British Geological Survey's GeoIndex Offshore (cultural data) theme are made available for viewing here. GeoIndex is a website that allows users to search for information about BGS data collections covering the UK and other areas world wide. Access is free, the interface is easy to use, and it has been developed to enable users to check coverage of different types of data and find out some background information about the data. More detailed information can be obtained by further enquiry via the web site: www.bgs.ac.uk/geoindex.</gco:CharacterString>
+            </gmd:abstract>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:organisationName>
+                        <gco:CharacterString>British Geological Survey</gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:phone>
+                                <gmd:CI_Telephone>
+                                    <gmd:voice>
+                                        <gco:CharacterString>+44 115 936 3143</gco:CharacterString>
+                                    </gmd:voice>
+                                    <gmd:facsimile>
+                                        <gco:CharacterString>+44 115 936 3276</gco:CharacterString>
+                                    </gmd:facsimile>
+                                </gmd:CI_Telephone>
+                            </gmd:phone>
+                            <gmd:address>
+                                <gmd:CI_Address>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:city>
+                                        <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                                    </gmd:city>
+                                    <gmd:administrativeArea>
+                                        <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                                    </gmd:administrativeArea>
+                                    <gmd:postalCode>
+                                        <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                                    </gmd:postalCode>
+                                    <gmd:country>
+                                        <gco:CharacterString>United Kingdom</gco:CharacterString>
+                                    </gmd:country>
+                                    <gmd:electronicMailAddress>
+                                        <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                </gmd:CI_Address>
+                            </gmd:address>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:organisationName>
+                        <gco:CharacterString>British Geological Survey</gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:phone>
+                                <gmd:CI_Telephone>
+                                    <gmd:voice>
+                                        <gco:CharacterString>+44 115 936 3100 Ex:3172</gco:CharacterString>
+                                    </gmd:voice>
+                                </gmd:CI_Telephone>
+                            </gmd:phone>
+                            <gmd:address>
+                                <gmd:CI_Address>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:city>
+                                        <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                                    </gmd:city>
+                                    <gmd:administrativeArea>
+                                        <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                                    </gmd:administrativeArea>
+                                    <gmd:postalCode>
+                                        <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                                    </gmd:postalCode>
+                                    <gmd:country>
+                                        <gco:CharacterString>United Kingdom</gco:CharacterString>
+                                    </gmd:country>
+                                    <gmd:electronicMailAddress>
+                                        <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                </gmd:CI_Address>
+                            </gmd:address>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:resourceMaintenance>
+                <gmd:MD_MaintenanceInformation>
+                    <gmd:maintenanceAndUpdateFrequency>
+                        <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+                    </gmd:maintenanceAndUpdateFrequency>
+                </gmd:MD_MaintenanceInformation>
+            </gmd:resourceMaintenance>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/concept?cp=13&amp;langcode=en&amp;ns=5" xlink:title="Geology">Geology</gmx:Anchor>
+                    </gmd:keyword>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>GEMET - INSPIRE themes</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2008-06-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>Digital maps</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>Marine geology</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>Geology</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>BGS Thesaurus of Geosciences</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2011</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>infoMapAccessService</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>ISO 19119:2005</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2008-04-16</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>NERC_DDC</gco:CharacterString>
+                    </gmd:keyword>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <!-- At least two gmd:resourceConstraints sections are expected here…  -->
+            <gmd:resourceConstraints xlink:title="Limitations">
+                <gmd:MD_LegalConstraints>
+                    <gmd:accessConstraints>
+                        <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+                    </gmd:accessConstraints>
+                    <gmd:otherConstraints>
+                        <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/INSPIRE_Directive_Article13_1e">Public access to spatial data sets and services would adversely affect intellectual property rights</gmx:Anchor>
+                    </gmd:otherConstraints>
+                </gmd:MD_LegalConstraints>
+            </gmd:resourceConstraints>
+            <gmd:resourceConstraints xlink:title="Conditions">
+                <gmd:MD_LegalConstraints>
+                    <gmd:useConstraints>
+                        <gmd:MD_RestrictionCode codeList="gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+                    </gmd:useConstraints>
+                    <gmd:otherConstraints>
+                        <gmx:Anchor xlink:href="#">Conditions apply</gmx:Anchor>
+                    </gmd:otherConstraints>
+                </gmd:MD_LegalConstraints>
+            </gmd:resourceConstraints>
+            <srv:serviceType>
+                <gco:LocalName codeSpace="INSPIRE">view</gco:LocalName>
+            </srv:serviceType>
+            <srv:extent>
+                <gmd:EX_Extent>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicDescription>
+                            <gmd:geographicIdentifier>
+                                <gmd:MD_Identifier>
+                                    <gmd:authority>
+                                        <gmd:CI_Citation>
+                                            <gmd:title>
+                                                <gco:CharacterString>ISO 3166_2</gco:CharacterString>
+                                            </gmd:title>
+                                            <gmd:date>
+                                                <gmd:CI_Date>
+                                                  <gmd:date>
+                                                  <gco:Date>2009</gco:Date>
+                                                  </gmd:date>
+                                                  <gmd:dateType>
+                                                  <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                                  </gmd:dateType>
+                                                </gmd:CI_Date>
+                                            </gmd:date>
+                                        </gmd:CI_Citation>
+                                    </gmd:authority>
+                                    <gmd:code>
+                                        <gco:CharacterString>GBN</gco:CharacterString>
+                                    </gmd:code>
+                                </gmd:MD_Identifier>
+                            </gmd:geographicIdentifier>
+                        </gmd:EX_GeographicDescription>
+                    </gmd:geographicElement>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicDescription>
+                            <gmd:geographicIdentifier>
+                                <gmd:MD_Identifier>
+                                    <gmd:authority>
+                                        <gmd:CI_Citation>
+                                            <gmd:title>
+                                                <gco:CharacterString>British Geological Survey Gazetteer: Geographical hierarchy from Geosaurus</gco:CharacterString>
+                                            </gmd:title>
+                                            <gmd:date>
+                                                <gmd:CI_Date>
+                                                  <gmd:date>
+                                                  <gco:Date>1979</gco:Date>
+                                                  </gmd:date>
+                                                  <gmd:dateType>
+                                                  <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                                  </gmd:dateType>
+                                                </gmd:CI_Date>
+                                            </gmd:date>
+                                        </gmd:CI_Citation>
+                                    </gmd:authority>
+                                    <gmd:code>
+                                        <gco:CharacterString>GREAT BRITAIN [id=139600]</gco:CharacterString>
+                                    </gmd:code>
+                                </gmd:MD_Identifier>
+                            </gmd:geographicIdentifier>
+                        </gmd:EX_GeographicDescription>
+                    </gmd:geographicElement>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicBoundingBox>
+                            <gmd:westBoundLongitude>
+                                <gco:Decimal>-9.0100</gco:Decimal>
+                            </gmd:westBoundLongitude>
+                            <gmd:eastBoundLongitude>
+                                <gco:Decimal>3.3400</gco:Decimal>
+                            </gmd:eastBoundLongitude>
+                            <gmd:southBoundLatitude>
+                                <gco:Decimal>49.2800</gco:Decimal>
+                            </gmd:southBoundLatitude>
+                            <gmd:northBoundLatitude>
+                                <gco:Decimal>61.4100</gco:Decimal>
+                            </gmd:northBoundLatitude>
+                        </gmd:EX_GeographicBoundingBox>
+                    </gmd:geographicElement>
+                    <gmd:temporalElement gco:nilReason="missing"/>
+                    <gmd:verticalElement gco:nilReason="inapplicable"/>
+                </gmd:EX_Extent>
+            </srv:extent>
+            <!-- GEMINI 2 says that this needs to be gco:nilReason="missing" -->
+            <srv:couplingType gco:nilReason="missing"/>
+            <!-- GEMINI 2 says that this needs to be gco:nilReason="missing" -->
+            <srv:containsOperations gco:nilReason="missing"/>
+            <srv:operatesOn
+                xlink:title="Map based index (GeoIndex) 1:50000 Series Geological Maps layer"
+                xlink:href="http://metadata.bgs.ac.uk/geonetwork/srv/en/csw?SERVICE=CSW&amp;REQUEST=GetRecordById&amp;ELEMENTSETNAME=full&amp;OUTPUTSCHEMA=http://www.isotc211.org/2005/gmd&amp;ID=9df8df53-2a7e-37a8-e044-0003ba9b0d98&amp;"
+                uuidref="9df8df53-2a7e-37a8-e044-0003ba9b0d98"/>
+            <srv:operatesOn
+                xlink:title="Map based index (GeoIndex) UTM (Universal Transverse Mercator) series 1:250000 Geological Maps layer"
+                xlink:href="http://metadata.bgs.ac.uk/geonetwork/srv/en/csw?SERVICE=CSW&amp;REQUEST=GetRecordById&amp;ELEMENTSETNAME=full&amp;OUTPUTSCHEMA=http://www.isotc211.org/2005/gmd&amp;ID=9df8df53-2a9b-37a8-e044-0003ba9b0d98&amp;"
+                uuidref="9df8df53-2a9b-37a8-e044-0003ba9b0d98"/>
+        </srv:SV_ServiceIdentification>
+    </gmd:identificationInfo>
+    <gmd:distributionInfo>
+        <gmd:MD_Distribution>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/svg+xml</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/gif</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/png</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/tiff</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/jpeg</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/bmp</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributor>
+                <gmd:MD_Distributor>
+                    <gmd:distributorContact>
+                        <gmd:CI_ResponsibleParty>
+                            <gmd:organisationName>
+                                <gco:CharacterString>British Geological Survey</gco:CharacterString>
+                            </gmd:organisationName>
+                            <gmd:contactInfo>
+                                <gmd:CI_Contact>
+                                    <gmd:phone>
+                                        <gmd:CI_Telephone>
+                                            <gmd:voice>
+                                                <gco:CharacterString>+44 115 936 3143</gco:CharacterString>
+                                            </gmd:voice>
+                                            <gmd:facsimile>
+                                                <gco:CharacterString>+44 115 936 3276</gco:CharacterString>
+                                            </gmd:facsimile>
+                                        </gmd:CI_Telephone>
+                                    </gmd:phone>
+                                    <gmd:address>
+                                        <gmd:CI_Address>
+                                            <gmd:deliveryPoint>
+                                                <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                                            </gmd:deliveryPoint>
+                                            <gmd:city>
+                                                <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                                            </gmd:city>
+                                            <gmd:administrativeArea>
+                                                <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                                            </gmd:administrativeArea>
+                                            <gmd:postalCode>
+                                                <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                                            </gmd:postalCode>
+                                            <gmd:country>
+                                                <gco:CharacterString>United Kingdom</gco:CharacterString>
+                                            </gmd:country>
+                                            <gmd:electronicMailAddress>
+                                                <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                                            </gmd:electronicMailAddress>
+                                        </gmd:CI_Address>
+                                    </gmd:address>
+                                </gmd:CI_Contact>
+                            </gmd:contactInfo>
+                            <gmd:role>
+                                <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+                            </gmd:role>
+                        </gmd:CI_ResponsibleParty>
+                    </gmd:distributorContact>
+                </gmd:MD_Distributor>
+            </gmd:distributor>
+            <gmd:transferOptions>
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:onLine>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://mapapps2.bgs.ac.uk/ArcGIS/services/GeoIndex_Offshore/Offshore_GeoIndex_Cultural/MapServer/WMSServer?service=WMS&amp;request=GetCapabilities</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>OGC:WMS-1.3.0-http-get-capabilities</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:name>
+                                <gco:CharacterString>BGS GeoIndex - Offshore (cultural data) data theme (OGC WxS INSPIRE)</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                                <gco:CharacterString>WMS version 1.3.0 GetCapabilities response document</gco:CharacterString>
+                            </gmd:description>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+            <gmd:transferOptions>
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:onLine>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://mapapps2.bgs.ac.uk/ArcGIS/services/GeoIndex_Offshore/Offshore_GeoIndex_Cultural/MapServer/WMSServer?</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>OGC:WMS-1.3.0-http-get-capabilities</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:name>
+                                <gco:CharacterString>BGS GeoIndex - Offshore (cultural data) data theme (OGC WxS INSPIRE)</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/endPoint">endPoint</gmx:Anchor>
+                            </gmd:description>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+            <gmd:transferOptions>
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:onLine>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://mapapps2.bgs.ac.uk/ArcGIS/services/GeoIndex_Offshore/Offshore_GeoIndex_Cultural/MapServer/WMSServer?service=WMS&amp;request=GetCapabilities&amp;version=1.1.1&amp;</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>OGC:WMS-1.1.1-http-get-capabilities</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:name>
+                                <gco:CharacterString>BGS GeoIndex - Offshore (cultural data) data theme (OGC WxS INSPIRE)</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                                <gco:CharacterString>GetCapabilities version 1.1.1 response document</gco:CharacterString>
+                            </gmd:description>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+        </gmd:MD_Distribution>
+    </gmd:distributionInfo>
+    <gmd:dataQualityInfo>
+        <gmd:DQ_DataQuality>
+            <gmd:scope>
+                <gmd:DQ_Scope>
+                    <gmd:level>
+                        <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="service">service</gmd:MD_ScopeCode>
+                    </gmd:level>
+                    <gmd:levelDescription>
+                        <gmd:MD_ScopeDescription>
+                            <gmd:other>
+                                <gco:CharacterString>service</gco:CharacterString>
+                            </gmd:other>
+                        </gmd:MD_ScopeDescription>
+                    </gmd:levelDescription>
+                </gmd:DQ_Scope>
+            </gmd:scope>
+            <gmd:report>
+                <gmd:DQ_DomainConsistency>
+                    <gmd:result>
+                        <gmd:DQ_ConformanceResult>
+                            <gmd:specification>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                        <gco:CharacterString>INSPIRE Implementing rules laying down technical arrangements for the interoperability and harmonisation of Geology</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                        <gmd:CI_Date>
+                                            <gmd:date>
+                                                <gco:Date>2011</gco:Date>
+                                            </gmd:date>
+                                            <gmd:dateType>
+                                                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                            </gmd:dateType>
+                                        </gmd:CI_Date>
+                                    </gmd:date>
+                                </gmd:CI_Citation>
+                            </gmd:specification>
+                            <gmd:explanation>
+                                <gco:CharacterString>See the referenced specification</gco:CharacterString>
+                            </gmd:explanation>
+                            <gmd:pass>
+                                <gco:Boolean>false</gco:Boolean>
+                            </gmd:pass>
+                        </gmd:DQ_ConformanceResult>
+                    </gmd:result>
+                </gmd:DQ_DomainConsistency>
+            </gmd:report>
+            <gmd:report>
+                <gmd:DQ_DomainConsistency>
+                    <gmd:result>
+                        <gmd:DQ_ConformanceResult>
+                            <gmd:specification>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                        <gco:CharacterString>Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                        <gmd:CI_Date>
+                                            <gmd:date>
+                                                <gco:Date>2010-12-08</gco:Date>
+                                            </gmd:date>
+                                            <gmd:dateType>
+                                                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                            </gmd:dateType>
+                                        </gmd:CI_Date>
+                                    </gmd:date>
+                                </gmd:CI_Citation>
+                            </gmd:specification>
+                            <gmd:explanation>
+                                <gco:CharacterString>See http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=OJ:L:2010:323:0011:0102:EN:PDF</gco:CharacterString>
+                            </gmd:explanation>
+                            <gmd:pass>
+                                <gco:Boolean>false</gco:Boolean>
+                            </gmd:pass>
+                        </gmd:DQ_ConformanceResult>
+                    </gmd:result>
+                </gmd:DQ_DomainConsistency>
+            </gmd:report>
+            <gmd:report>
+                <gmd:DQ_DomainConsistency>
+                    <gmd:result>
+                        <gmd:DQ_ConformanceResult>
+                            <gmd:specification>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                        <gco:CharacterString>Technical Guidance for the implementation of INSPIRE View Services Version 3.0</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                        <gmd:CI_Date>
+                                            <gmd:date>
+                                                <gco:Date>2011-03-21</gco:Date>
+                                            </gmd:date>
+                                            <gmd:dateType>
+                                                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                            </gmd:dateType>
+                                        </gmd:CI_Date>
+                                    </gmd:date>
+                                </gmd:CI_Citation>
+                            </gmd:specification>
+                            <gmd:explanation>
+                                <gco:CharacterString>See the referenced specification at http://inspire.jrc.ec.europa.eu/documents/Network_Services/TechnicalGuidance_ViewServices_v3.0.pdf</gco:CharacterString>
+                            </gmd:explanation>
+                            <gmd:pass>
+                                <gco:Boolean>false</gco:Boolean>
+                            </gmd:pass>
+                        </gmd:DQ_ConformanceResult>
+                    </gmd:result>
+                </gmd:DQ_DomainConsistency>
+            </gmd:report>
+            <gmd:lineage>
+                <gmd:LI_Lineage>
+                    <gmd:statement>
+                        <gco:CharacterString>For lineage of datasets served by this service please refer to the metadata for those data.</gco:CharacterString>
+                    </gmd:statement>
+                </gmd:LI_Lineage>
+            </gmd:lineage>
+        </gmd:DQ_DataQuality>
+    </gmd:dataQualityInfo>
+</gmd:MD_Metadata>

--- a/ckanext/spatial/tests/xml/gemini2.3/validation/InvalidGemini2_3.xml
+++ b/ckanext/spatial/tests/xml/gemini2.3/validation/InvalidGemini2_3.xml
@@ -1,0 +1,736 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gsr="http://www.isotc211.org/2005/gsr"
+    xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts"
+    xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:geonet="http://www.fao.org/geonetwork"
+    xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://inspire.ec.europa.eu/draft-schemas/inspire-md-schemas/apiso-inspire/apiso-inspire.xsd">
+    <gmd:fileIdentifier>
+        <gco:CharacterString>ea819b92-d389-193a-e044-002128a47908</gco:CharacterString>
+    </gmd:fileIdentifier>
+    <gmd:parentIdentifier gco:nilReason="inapplicable"/>
+    <gmd:hierarchyLevel>
+        <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="service">service</gmd:MD_ScopeCode>
+    </gmd:hierarchyLevel>
+    <gmd:hierarchyLevelName>
+        <gmx:Anchor>service</gmx:Anchor>
+    </gmd:hierarchyLevelName>
+    <gmd:contact>
+        <gmd:CI_ResponsibleParty>
+            <gmd:individualName>
+                <gco:CharacterString>Bell,Patrick D</gco:CharacterString>
+            </gmd:individualName>
+            <gmd:organisationName>
+                <gco:CharacterString>British Geological Survey</gco:CharacterString>
+            </gmd:organisationName>
+            <gmd:positionName>
+                <gco:CharacterString>NERC-BGS TL Web Systems</gco:CharacterString>
+            </gmd:positionName>
+            <gmd:contactInfo>
+                <gmd:CI_Contact>
+                    <gmd:phone>
+                        <gmd:CI_Telephone>
+                            <gmd:voice>
+                                <gco:CharacterString>+44 115 936 3100 Ex:3075</gco:CharacterString>
+                            </gmd:voice>
+                        </gmd:CI_Telephone>
+                    </gmd:phone>
+                    <gmd:address>
+                        <gmd:CI_Address>
+                            <gmd:deliveryPoint>
+                                <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                            </gmd:deliveryPoint>
+                            <gmd:city>
+                                <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                            </gmd:city>
+                            <gmd:administrativeArea>
+                                <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                            </gmd:administrativeArea>
+                            <gmd:postalCode>
+                                <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                            </gmd:postalCode>
+                            <gmd:country>
+                                <gco:CharacterString>United Kingdom</gco:CharacterString>
+                            </gmd:country>
+                            <gmd:electronicMailAddress>
+                                <gco:CharacterString>pdbe@bgs.ac.uk</gco:CharacterString>
+                            </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                    </gmd:address>
+                </gmd:CI_Contact>
+            </gmd:contactInfo>
+            <gmd:role>
+                <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+            </gmd:role>
+        </gmd:CI_ResponsibleParty>
+    </gmd:contact>
+    <gmd:dateStamp>
+        <gco:Date>2014-06-23</gco:Date>
+    </gmd:dateStamp>
+    <gmd:metadataStandardName>
+        <gco:CharacterString>NERC profile of ISO19115:2003</gco:CharacterString>
+    </gmd:metadataStandardName>
+    <gmd:metadataStandardVersion>
+        <gco:CharacterString>1.0</gco:CharacterString>
+    </gmd:metadataStandardVersion>
+    <gmd:dataSetURI>
+        <gco:CharacterString>http://data.bgs.ac.uk/id/dataHolding/13605835</gco:CharacterString>
+    </gmd:dataSetURI>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2006</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gco:CharacterString>urn:ogc:def:crs:EPSG::27700</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>OGP</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gco:CharacterString>urn:ogc:def:crs:EPSG::32631</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>OGP</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gco:CharacterString>urn:ogc:def:crs:EPSG::3857</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>OGP</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gco:CharacterString>urn:ogc:def:crs:EPSG::4258</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>OGP</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:authority>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>www.epsg.org</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2005</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:authority>
+                    <gmd:code>
+                        <gco:CharacterString>urn:ogc:def:crs:EPSG::4326</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>OGP</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:identificationInfo>
+        <srv:SV_ServiceIdentification>
+            <gmd:citation>
+                <gmd:CI_Citation>
+                    <gmd:title>
+                        <gco:CharacterString>BGS GeoIndex - Offshore (cultural data) data theme (OGC WxS INSPIRE)</gco:CharacterString>
+                    </gmd:title>
+                    <gmd:alternateTitle>
+                        <gco:CharacterString>GIOFF...</gco:CharacterString>
+                    </gmd:alternateTitle>
+                    <gmd:date>
+                        <gmd:CI_Date>
+                            <gmd:date>
+                                <gco:Date>2013</gco:Date>
+                            </gmd:date>
+                            <gmd:dateType>
+                                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                            </gmd:dateType>
+                        </gmd:CI_Date>
+                    </gmd:date>
+                    <gmd:identifier>
+                        <gmd:MD_Identifier id="_1">
+                            <gmd:code>
+                                <gco:CharacterString>http://data.bgs.ac.uk/id/dataHolding/13605835</gco:CharacterString>
+                            </gmd:code>
+                        </gmd:MD_Identifier>
+                    </gmd:identifier>
+                </gmd:CI_Citation>
+            </gmd:citation>
+            <gmd:abstract>
+                <gco:CharacterString>Very short abstract.</gco:CharacterString>
+            </gmd:abstract>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:organisationName>
+                        <gco:CharacterString>British Geological Survey</gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:phone>
+                                <gmd:CI_Telephone>
+                                    <gmd:voice>
+                                        <gco:CharacterString>+44 115 936 3143</gco:CharacterString>
+                                    </gmd:voice>
+                                    <gmd:facsimile>
+                                        <gco:CharacterString>+44 115 936 3276</gco:CharacterString>
+                                    </gmd:facsimile>
+                                </gmd:CI_Telephone>
+                            </gmd:phone>
+                            <gmd:address>
+                                <gmd:CI_Address>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:city>
+                                        <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                                    </gmd:city>
+                                    <gmd:administrativeArea>
+                                        <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                                    </gmd:administrativeArea>
+                                    <gmd:postalCode>
+                                        <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                                    </gmd:postalCode>
+                                    <gmd:country>
+                                        <gco:CharacterString>United Kingdom</gco:CharacterString>
+                                    </gmd:country>
+                                    <gmd:electronicMailAddress>
+                                        <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                </gmd:CI_Address>
+                            </gmd:address>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:organisationName>
+                        <gco:CharacterString>British Geological Survey</gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:phone>
+                                <gmd:CI_Telephone>
+                                    <gmd:voice>
+                                        <gco:CharacterString>+44 115 936 3100 Ex:3172</gco:CharacterString>
+                                    </gmd:voice>
+                                </gmd:CI_Telephone>
+                            </gmd:phone>
+                            <gmd:address>
+                                <gmd:CI_Address>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:city>
+                                        <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                                    </gmd:city>
+                                    <gmd:administrativeArea>
+                                        <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                                    </gmd:administrativeArea>
+                                    <gmd:postalCode>
+                                        <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                                    </gmd:postalCode>
+                                    <gmd:country>
+                                        <gco:CharacterString>United Kingdom</gco:CharacterString>
+                                    </gmd:country>
+                                    <gmd:electronicMailAddress>
+                                        <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                </gmd:CI_Address>
+                            </gmd:address>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:resourceMaintenance>
+                <gmd:MD_MaintenanceInformation>
+                    <gmd:maintenanceAndUpdateFrequency>
+                        <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+                    </gmd:maintenanceAndUpdateFrequency>
+                </gmd:MD_MaintenanceInformation>
+            </gmd:resourceMaintenance>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/concept?cp=13&amp;langcode=en&amp;ns=5" xlink:title="Geology">Geology</gmx:Anchor>
+                    </gmd:keyword>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>GEMET - INSPIRE themes</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2008-06-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>Digital maps</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>Marine geology</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>Geology</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>BGS Thesaurus of Geosciences</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2011</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>infoMapAccessService</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>ISO 19119:2005</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2008-04-16</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>NERC_DDC</gco:CharacterString>
+                    </gmd:keyword>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <!-- At least two gmd:resourceConstraints sections are expected here…  -->
+            <gmd:resourceConstraints xlink:title="Limitations">
+                <gmd:MD_LegalConstraints>
+                    <gmd:accessConstraints>
+                        <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+                    </gmd:accessConstraints>
+                    <gmd:otherConstraints>
+                        <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/INSPIRE_Directive_Article13_1e">Public access to spatial data sets and services would adversely affect intellectual property rights</gmx:Anchor>
+                    </gmd:otherConstraints>
+                </gmd:MD_LegalConstraints>
+            </gmd:resourceConstraints>
+            <srv:serviceType>
+                <gco:LocalName codeSpace="INSPIRE">view</gco:LocalName>
+            </srv:serviceType>
+            <srv:extent>
+                <gmd:EX_Extent>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicDescription>
+                            <gmd:geographicIdentifier>
+                                <gmd:MD_Identifier>
+                                    <gmd:authority>
+                                        <gmd:CI_Citation>
+                                            <gmd:title>
+                                                <gco:CharacterString>ISO 3166_2</gco:CharacterString>
+                                            </gmd:title>
+                                            <gmd:date>
+                                                <gmd:CI_Date>
+                                                  <gmd:date>
+                                                  <gco:Date>2009</gco:Date>
+                                                  </gmd:date>
+                                                  <gmd:dateType>
+                                                  <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                                  </gmd:dateType>
+                                                </gmd:CI_Date>
+                                            </gmd:date>
+                                        </gmd:CI_Citation>
+                                    </gmd:authority>
+                                    <gmd:code>
+                                        <gco:CharacterString>GBN</gco:CharacterString>
+                                    </gmd:code>
+                                </gmd:MD_Identifier>
+                            </gmd:geographicIdentifier>
+                        </gmd:EX_GeographicDescription>
+                    </gmd:geographicElement>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicDescription>
+                            <gmd:geographicIdentifier>
+                                <gmd:MD_Identifier>
+                                    <gmd:authority>
+                                        <gmd:CI_Citation>
+                                            <gmd:title>
+                                                <gco:CharacterString>British Geological Survey Gazetteer: Geographical hierarchy from Geosaurus</gco:CharacterString>
+                                            </gmd:title>
+                                            <gmd:date>
+                                                <gmd:CI_Date>
+                                                  <gmd:date>
+                                                  <gco:Date>1979</gco:Date>
+                                                  </gmd:date>
+                                                  <gmd:dateType>
+                                                  <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                                  </gmd:dateType>
+                                                </gmd:CI_Date>
+                                            </gmd:date>
+                                        </gmd:CI_Citation>
+                                    </gmd:authority>
+                                    <gmd:code>
+                                        <gco:CharacterString>GREAT BRITAIN [id=139600]</gco:CharacterString>
+                                    </gmd:code>
+                                </gmd:MD_Identifier>
+                            </gmd:geographicIdentifier>
+                        </gmd:EX_GeographicDescription>
+                    </gmd:geographicElement>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicBoundingBox>
+                            <gmd:westBoundLongitude>
+                                <gco:Decimal>-9.0100</gco:Decimal>
+                            </gmd:westBoundLongitude>
+                            <gmd:eastBoundLongitude>
+                                <gco:Decimal>3.3400</gco:Decimal>
+                            </gmd:eastBoundLongitude>
+                            <gmd:southBoundLatitude>
+                                <gco:Decimal>49.2800</gco:Decimal>
+                            </gmd:southBoundLatitude>
+                            <gmd:northBoundLatitude>
+                                <gco:Decimal>61.4100</gco:Decimal>
+                            </gmd:northBoundLatitude>
+                        </gmd:EX_GeographicBoundingBox>
+                    </gmd:geographicElement>
+                    <gmd:temporalElement gco:nilReason="missing"/>
+                    <gmd:verticalElement gco:nilReason="inapplicable"/>
+                </gmd:EX_Extent>
+            </srv:extent>
+            <!-- GEMINI 2 says that this needs to be gco:nilReason="missing" -->
+            <srv:couplingType gco:nilReason="missing"/>
+            <!-- GEMINI 2 says that this needs to be gco:nilReason="missing" -->
+            <srv:containsOperations gco:nilReason="missing"/>
+            <srv:operatesOn
+                xlink:title="Map based index (GeoIndex) 1:50000 Series Geological Maps layer"
+                xlink:href="http://metadata.bgs.ac.uk/geonetwork/srv/en/csw?SERVICE=CSW&amp;REQUEST=GetRecordById&amp;ELEMENTSETNAME=full&amp;OUTPUTSCHEMA=http://www.isotc211.org/2005/gmd&amp;ID=9df8df53-2a7e-37a8-e044-0003ba9b0d98&amp;"
+                uuidref="9df8df53-2a7e-37a8-e044-0003ba9b0d98"/>
+            <srv:operatesOn
+                xlink:title="Map based index (GeoIndex) UTM (Universal Transverse Mercator) series 1:250000 Geological Maps layer"
+                xlink:href="http://metadata.bgs.ac.uk/geonetwork/srv/en/csw?SERVICE=CSW&amp;REQUEST=GetRecordById&amp;ELEMENTSETNAME=full&amp;OUTPUTSCHEMA=http://www.isotc211.org/2005/gmd&amp;ID=9df8df53-2a9b-37a8-e044-0003ba9b0d98&amp;"
+                uuidref="9df8df53-2a9b-37a8-e044-0003ba9b0d98"/>
+        </srv:SV_ServiceIdentification>
+    </gmd:identificationInfo>
+    <gmd:distributionInfo>
+        <gmd:MD_Distribution>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/svg+xml</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/gif</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/png</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/tiff</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/jpeg</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>image/bmp</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributor>
+                <gmd:MD_Distributor>
+                    <gmd:distributorContact>
+                        <gmd:CI_ResponsibleParty>
+                            <gmd:organisationName>
+                                <gco:CharacterString>British Geological Survey</gco:CharacterString>
+                            </gmd:organisationName>
+                            <gmd:contactInfo>
+                                <gmd:CI_Contact>
+                                    <gmd:phone>
+                                        <gmd:CI_Telephone>
+                                            <gmd:voice>
+                                                <gco:CharacterString>+44 115 936 3143</gco:CharacterString>
+                                            </gmd:voice>
+                                            <gmd:facsimile>
+                                                <gco:CharacterString>+44 115 936 3276</gco:CharacterString>
+                                            </gmd:facsimile>
+                                        </gmd:CI_Telephone>
+                                    </gmd:phone>
+                                    <gmd:address>
+                                        <gmd:CI_Address>
+                                            <gmd:deliveryPoint>
+                                                <gco:CharacterString>Environmental Science Centre,Keyworth</gco:CharacterString>
+                                            </gmd:deliveryPoint>
+                                            <gmd:city>
+                                                <gco:CharacterString>NOTTINGHAM</gco:CharacterString>
+                                            </gmd:city>
+                                            <gmd:administrativeArea>
+                                                <gco:CharacterString>NOTTINGHAMSHIRE</gco:CharacterString>
+                                            </gmd:administrativeArea>
+                                            <gmd:postalCode>
+                                                <gco:CharacterString>NG12 5GG</gco:CharacterString>
+                                            </gmd:postalCode>
+                                            <gmd:country>
+                                                <gco:CharacterString>United Kingdom</gco:CharacterString>
+                                            </gmd:country>
+                                            <gmd:electronicMailAddress>
+                                                <gco:CharacterString>enquiries@bgs.ac.uk</gco:CharacterString>
+                                            </gmd:electronicMailAddress>
+                                        </gmd:CI_Address>
+                                    </gmd:address>
+                                </gmd:CI_Contact>
+                            </gmd:contactInfo>
+                            <gmd:role>
+                                <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+                            </gmd:role>
+                        </gmd:CI_ResponsibleParty>
+                    </gmd:distributorContact>
+                </gmd:MD_Distributor>
+            </gmd:distributor>
+            <gmd:transferOptions>
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:onLine>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://mapapps2.bgs.ac.uk/ArcGIS/services/GeoIndex_Offshore/Offshore_GeoIndex_Cultural/MapServer/WMSServer?service=WMS&amp;request=GetCapabilities</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>OGC:WMS-1.3.0-http-get-capabilities</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:name>
+                                <gco:CharacterString>BGS GeoIndex - Offshore (cultural data) data theme (OGC WxS INSPIRE)</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                                <gco:CharacterString>WMS version 1.3.0 GetCapabilities response document</gco:CharacterString>
+                            </gmd:description>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+            <gmd:transferOptions>
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:onLine>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://mapapps2.bgs.ac.uk/ArcGIS/services/GeoIndex_Offshore/Offshore_GeoIndex_Cultural/MapServer/WMSServer?</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>OGC:WMS-1.3.0-http-get-capabilities</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:name>
+                                <gco:CharacterString>BGS GeoIndex - Offshore (cultural data) data theme (OGC WxS INSPIRE)</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/endPoint">endPoint</gmx:Anchor>
+                            </gmd:description>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+            <gmd:transferOptions>
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:onLine>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://mapapps2.bgs.ac.uk/ArcGIS/services/GeoIndex_Offshore/Offshore_GeoIndex_Cultural/MapServer/WMSServer?service=WMS&amp;request=GetCapabilities&amp;version=1.1.1&amp;</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>OGC:WMS-1.1.1-http-get-capabilities</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:name>
+                                <gco:CharacterString>BGS GeoIndex - Offshore (cultural data) data theme (OGC WxS INSPIRE)</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                                <gco:CharacterString>GetCapabilities version 1.1.1 response document</gco:CharacterString>
+                            </gmd:description>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+        </gmd:MD_Distribution>
+    </gmd:distributionInfo>
+</gmd:MD_Metadata>

--- a/ckanext/spatial/validation/xml/gemini2/GEMINI_2.3_Schematron_Schema-v1.0.sch
+++ b/ckanext/spatial/validation/xml/gemini2/GEMINI_2.3_Schematron_Schema-v1.0.sch
@@ -1,0 +1,1353 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ========================================================================================== -->
+<!-- Schematron Schema for the UK GEMINI Standard Version 2.3                             -->
+<!-- ========================================================================================== -->
+<!-- 
+     James Passmore                                
+     British Geological Survey                                                
+     2017-09-08
+     
+     This Schematron schema has been developed for the UK Location Programme (UKLP) by
+     British Geological Survey (BGS), with funding from AGI.
+
+     It is designed to validate the constraints introduced in the GEMINI2.3 draft standard.
+     Constraints have been taken from:
+     
+     UK GEMINI Standard, Version 2.3, September 2017.
+     
+     The schema has been developed for XSLT Version 1.0, and is based on the GEMINI 2.1 schematron, 
+     which was tested with the ISO 19757-3 Schematron XML Stylesheets issued on 2009-03-18 at:
+     http://www.schematron.com/tmp/iso-schematron-xslt1.zip (no longer available).
+     
+     The schema tests constraints on ISO / TS 19139 encoded metadata. The rules expressed in this 
+     schema apply in addition to validation by the ISO / TS 19139 XML schemas.
+     
+     The schema is designed to test ISO 19139 encoded metadata incorporating ISO 19136 (GML Version
+     3.2.1) elements where necessary. Note that GML elements must be mapped to the Version 3.2.1 
+     GML namespace - http://www.opengis.net/gml/3.2
+
+     You may use and re-use the information in this publication (not including logos) free of charge
+     in any format or medium, under the terms of the Open Government Licence.
+
+     Document History:
+     
+     2017-09-08 - Modified from GEMINI 2.1 Schematron Schema.sch
+                ~ All contexts changed to allow checking of metadata either as CSW response or standalone metadata record
+                ~ Namespace prefixes for all relevant XML schema added.
+     2017-11-14 - Release Candidate 1
+                ~ Added/amened rules for clarifications and changes for GEMINI 2.3
+     2017-12-11 - Release Candidate 2 
+                ~ removed Copyright statement, appropriate copyright still needs to be added
+                ~ removed Gemini2-mi47-services-restriction as it doesn't apply.
+                ~ added brackets around Unique for Resource Identifier text.
+     2018-03-13 ~ Release Candidate 3
+                ~ Added unique prefixes to all asserts/reports to allow esier debugging/reporting
+                ~ Re-added Gemini2-mi47-services-restriction as it does apply (cf. TG Requirement 3.1:)
+                ~ Added length test to Abstract
+                ~ correction to count test in Quality Scope
+                ~ added ancillary test (at-8) for ensuring reported scopes don't clash
+                ~ corrected issue in Data Format
+                ~ added abstract pattern TypeNillableVersionPattern
+     2018-03-14 ~ Release Candidate 4
+                ~ Removed ancillary test (at-8)
+     2018-04-11 ~ Release Candidate 5
+                ~ replaced references to XML files on BGS development server for files on AGI server
+     2018-04-26 ~ Release Candidate 6
+                ~ Spelling corrections/formatting
+                ~ added pattern to Spatial representation type
+                ~ corrected context in Conformity
+                ~ added rule to hierarchyLevelName
+                ~ corrected context in Topological consistency
+                ~ added to list of nil version terms in Data Format
+                ~ corrected context in Data Format
+                ~ removed Ancillary test metadata/2.0/req/common/root-element as not testing the requirement
+    2018-05-17  ~ Release Candidate 7
+                ~ Added hints to possible locations for Abstract patterns
+                ~ Added Metadata Item (titles) to MI debug reports
+                ~ Removed requirement for gmd:useLimitation in MI-26 (Use Constraints) as superseded by new requirements
+                ~ Added AT-8 to test we have at least two legal requirements sections.
+                ~ Added new rule and removed old rules in Limitations on Public Access
+                ~ Added IsoCodeListPattern to MI-26 (Use Constraints)
+    2018-05-21  ~ Release Candidate 8
+                ~ moved first sch:p to beneath last sch:ns, for compliance to RELAX NG schema for Schematron
+                ~ moved sch:lets for debug reporting to top, for compliance to RELAX NG schema for Schematron
+    2018-07-03  ~ Release Candidate 9
+                ~ updated reference XML files to location on https://agi.org.uk/ 
+-->
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt" schemaVersion="1.2">
+  <sch:title>UK GEMINI Standard Draft Version 2.3</sch:title>
+  <!-- Namespaces from ISO 19139 Metadata encoding -->
+  <sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <!-- Namespace for ISO 19119 - Metadata Describing Services -->
+  <sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
+  <!-- Namespace for ISO 19136 - Geography Mark-up Language -->
+  <sch:ns prefix="gml" uri="http://www.opengis.net/gml/3.2"/>
+  <sch:ns prefix="gml32" uri="http://www.opengis.net/gml/3.2"/>
+  <!-- Namespace for CSW responses -->
+  <sch:ns prefix="csw" uri="http://www.opengis.net/cat/csw/2.0.2"/>
+  <!-- Namespace other -->
+  <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+  <sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+  <sch:ns uri="http://www.isotc211.org/2005/gss" prefix="gss"/>
+  <sch:ns uri="http://www.isotc211.org/2005/gts" prefix="gts"/>
+  <sch:ns uri="http://www.isotc211.org/2005/gsr" prefix="gsr"/>
+  <sch:p>This Schematron schema is designed to test the constraints introduced in the GEMINI2 discovery metadata standard.</sch:p>
+  <!-- Define some generic parameters -->
+  <sch:let name="hierarchyLevelCLValue"
+    value="//gmd:MD_Metadata/gmd:hierarchyLevel[1]/gmd:MD_ScopeCode[1]/@codeListValue"/>
+  <!-- IR titles -->
+  <sch:let name="inspire1089"
+    value="'Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services'"/>
+  <sch:let name="inspire1089x"
+    value="'COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services'"/>
+  <sch:let name="inspire976"
+    value="'Commission Regulation (EC) No 976/2009 of 19 October 2009 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards the Network Services'"/>
+  <!-- External documents -->
+  <sch:let name="defaultCRScodes"
+    value="document('https://agi.org.uk/images/xslt/d4.xml')"/>
+  <sch:let name="charSetCodes"
+    value="document('https://agi.org.uk/images/xslt/MD_CharacterSetCode.xml')"/>
+  <!-- Text for validation reporting -->
+  <sch:let name="LPreportsupplement"
+    value="'This test may be called by the following Metadata Items: 3 - Dataset Language and 33 - Metadata Language'"/>
+  <sch:let name="RPreportsupplement"
+    value="'This test may be called by the following Metadata Items: 23 - Responsible Organisation and 35 - Metadata Point of Contact'"/>
+  <sch:let name="GBreportsupplement" value="'Issue in Metadata item 44: Bounding box'"/>
+  <!-- ========================================================================================== -->
+  <!-- Concrete Patterns                                                                          -->
+  <!-- ========================================================================================== -->
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 1 - Title                                                                    -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi1">
+    <sch:title>Title</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi1-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:citation/*[1]/gmd:title"/>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 2 - Alternative Title                                                        -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi2">
+    <sch:title>Alternative Title</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi2-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:citation/*[1]/gmd:alternateTitle"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 3 - Dataset Language                                                         -->
+  <!-- No change for natural dataset language (code zxx)                                          -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi3">
+    <sch:title>Dataset Language</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="LanguagePattern" id="Gemini2-mi3-Language">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:language"/>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 4 - Abstract                                                                 -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi4">
+    <sch:title>Abstract</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi4-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:abstract"/>
+  </sch:pattern>
+  <sch:pattern fpi="metadata/2.0/req/common/resource-abstract">
+    <sch:title>Abstract free-text element check</sch:title>
+    <sch:p>A human readable, non-empty description of the dataset, dataset series or service shall
+      be provided</sch:p>
+    <sch:rule context="//gmd:abstract">
+      <sch:assert test="normalize-space(.) and *"> MI-4a (Abstract): A human readable, non-empty description of
+        the dataset, dataset series, or service shall be provided </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="metadata/2.0/req/common/resource-abstract-len">
+    <sch:title>Abstract length check</sch:title>
+    <sch:rule context="//gmd:abstract/*[1]">
+      <sch:assert test="string-length() &gt; 99"> MI-4b (Abstract): Abstract is too short. GEMINI 2.3 requires
+        an abstract of at least 100 characters, but abstract "<sch:value-of
+          select="normalize-space(.)"/>" has only <sch:value-of select="string-length(.)"/>
+        characters </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="metadata/2.0/req/common/resource-abstract-text">
+    <sch:title>Abstract is not the same as Title...</sch:title>
+    <sch:rule context="//gmd:abstract/*[1]">
+      <sch:let name="resourceTitle"
+        value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:citation/*[1]/gmd:title/*[1][normalize-space()]"/>
+      <sch:let name="resourceAbstract" value="normalize-space(.)"/>
+      <sch:assert test="$resourceAbstract != $resourceTitle"> MI-4c (Abstract): Abstract "<sch:value-of
+          select="$resourceAbstract"/>" must not be the same text as the title "<sch:value-of
+          select="$resourceTitle"/>")). </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 5 - Topic Category                                                           -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi5">
+    <sch:title>Topic Category</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]">
+      <sch:assert
+        test="
+          ((../../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'dataset' or
+          ../../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'series') and
+          count(gmd:topicCategory) >= 1) or
+          (../../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'dataset' and
+          ../../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'series') or
+          count(../../gmd:hierarchyLevel) = 0"
+        >MI-5a (Topic Category): Topic category is mandatory for datasets and series. One or more shall be provided.
+      </sch:assert>
+    </sch:rule>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:topicCategory">
+      <sch:assert
+        test="
+          ((../../../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'dataset' or
+          ../../../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'series') and
+          count(@gco:nilReason) = 0) or
+          (../../../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'dataset' and
+          ../../../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'series') or
+          count(../../../gmd:hierarchyLevel) = 0"
+        >MI-5b (Topic Category): Topic Category shall not be null. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 6 - Keyword                                                                  -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi6">
+    <sch:title>Keyword</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]">
+      <sch:assert test="count(gmd:descriptiveKeywords) &gt;= 1"> MI-6 (Keyword): Descriptive keywords are
+        mandatory. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi6-Keyword-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:descriptiveKeywords/*[1]/gmd:keyword"
+    />
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi6-Thesaurus-Title-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:descriptiveKeywords/*[1]/gmd:thesaurusName/*[1]/gmd:title"
+    />
+  </sch:pattern>
+  <sch:pattern is-a="IsoCodeListPattern" id="Gemini2-mi6-Thesaurus-DateType-CodeList">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:descriptiveKeywords/*[1]/gmd:thesaurusName/*[1]/gmd:date/*[1]/gmd:dateType/*[1]"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 7 - Temporal Extent                                                          -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi7">
+    <sch:title>Temporal extent</sch:title>
+    <sch:rule
+      context="
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent">
+      <sch:assert test="count(gml:TimePeriod) = 1 or count(gml:TimeInstant) = 1"> MI-7a (Temporal Extent): Temporal
+        extent shall be implemented using gml:TimePeriod or gml:TimeInstant. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi7-endpos">
+    <sch:rule
+      context="
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod/gml:endPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod/gml:endPosition">
+      <sch:report
+        test="((@indeterminatePosition = 'unknown' or @indeterminatePosition = 'now') and normalize-space(.))"
+        > MI-7b (Temporal Extent): When indeterminatePosition='unknown' or indeterminatePosition='now' are specified
+        endPosition should be empty </sch:report>
+      <sch:assert
+        test="string-length() = 0 or string-length() = 4 or string-length() = 7 or string-length() = 10 or string-length() = 19"
+        > MI-7c (Temporal Extent): Date string doesn't have correct length, check it conforms to Gregorian calendar
+        and UTC as per ISO 8601 </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi7-begpos">
+    <sch:rule
+      context="
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod/gml:beginPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod/gml:beginPosition">
+      <sch:report test="(@indeterminatePosition = 'unknown' and normalize-space(.))"> MI-7d (Temporal Extent): When
+        indeterminatePosition='unknown' is specified beginPosition should be empty </sch:report>
+      <sch:assert
+        test="string-length() = 0 or string-length() = 4 or string-length() = 7 or string-length() = 10 or string-length() = 19"
+        > MI-7e (Temporal Extent): Date string doesn't have correct length, check it conforms to Gregorian calendar
+        and UTC as per ISO 8601 </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 8 - Dataset Reference Date                                                   -->
+  <!-- Also see ancilliary tests (Gemini2-at5)                                                    -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi8">
+    <sch:title>Dataset reference date</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="IsoCodeListPattern" id="Gemini2-mi8-ReferenceDate-DateType-CodeList">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:citation/*[1]/gmd:date/*[1]/gmd:dateType/*[1]"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 10 - Lineage                                                                 -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi10">
+    <sch:title>Lineage</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]">
+      <sch:assert
+        test="
+          ((gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'dataset' or
+          gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'series') and
+          count(gmd:dataQualityInfo[1]/*[1]/gmd:lineage/*[1]/gmd:statement) = 1) or
+          (gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'dataset' and
+          gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'series') or
+          count(gmd:hierarchyLevel) = 0"
+        > MI-10a (Lineage): Lineage is mandatory for datasets and series. One shall be provided. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi10-Statement-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:dataQualityInfo[1]/*[1]/gmd:lineage/*[1]/gmd:statement"/>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi10-scoped">
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:dataQualityInfo[1]/gmd:DQ_DataQuality[1]/gmd:scope[1]/gmd:DQ_Scope[1]/gmd:level[1]/gmd:MD_ScopeCode[1][@codeListValue = 'dataset']">
+      <sch:assert
+        test="count(parent::gmd:level/parent::gmd:DQ_Scope/parent::gmd:scope/following-sibling::gmd:lineage) = 1"
+        > MI-10b (Lineage): The gmd:dataQualityInfo scoped to dataset must have a lineage section
+      </sch:assert>
+    </sch:rule>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:dataQualityInfo[1]/gmd:DQ_DataQuality[1]/gmd:scope[1]/gmd:DQ_Scope[1]/gmd:level[1]/gmd:MD_ScopeCode[1][@codeListValue = 'series']">
+      <sch:assert
+        test="count(parent::gmd:level/parent::gmd:DQ_Scope/parent::gmd:scope/following-sibling::gmd:lineage) = 1"
+        > MI-10c (Lineage): The gmd:dataQualityInfo scoped to series must have a lineage section </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 11, 12, 13, 14 - Geographic Bounding Box                                     -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi11">
+    <sch:title>West and East longitude, North and South latitude</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]">
+      <sch:assert
+        test="
+          ((../../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'dataset' or
+          ../../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'series') and
+          (count(gmd:extent/*[1]/gmd:geographicElement/gmd:EX_GeographicBoundingBox) &gt;= 1) or
+          count(gmd:extent/*[1]/gmd:geographicElement/*[@gco:isoType = 'gmd:EX_GeographicBoundingBox'][1]) &gt;= 1) or
+          (../../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'dataset' and
+          ../../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'series') or
+          count(../../gmd:hierarchyLevel) = 0"
+        > MI-(11,12,13,13  Geographic Bounding Box): Geographic bounding box is mandatory for datasets and series. One or
+        more shall be provided. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="GeographicBoundingBoxPattern" id="Gemini2-mi11-BoundingBox">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:geographicElement/gmd:EX_GeographicBoundingBox |
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:geographicElement/*[@gco:isoType='gmd:EX_GeographicBoundingBox'] [1]|
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:geographicElement/gmd:EX_GeographicBoundingBox |
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:geographicElement/*[@gco:isoType='gmd:EX_GeographicBoundingBox'][1]"
+    />
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi11-West-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:geographicElement/*[1]/gmd:westBoundLongitude |
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:geographicElement/*[1]/gmd:westBoundLongitude"
+    />
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi11-East-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:geographicElement/*[1]/gmd:eastBoundLongitude |
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:geographicElement/*[1]/gmd:eastBoundLongitude"
+    />
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi11-South-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:geographicElement/*[1]/gmd:southBoundLatitude |
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:geographicElement/*[1]/gmd:southBoundLatitude"
+    />
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mill-North-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:geographicElement/*[1]/gmd:northBoundLatitude |
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:geographicElement/*[1]/gmd:northBoundLatitude"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 15 - Extent                                                                  -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi15">
+    <sch:title>Extent</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi15-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:geographicElement/gmd:EX_GeographicDescription/gmd:geographicIdentifier/*[1]/gmd:code | 
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:geographicElement/*[@gco:isoType='gmd:EX_GeographicDescription'][1]/gmd:geographicIdentifier/*[1]/gmd:code |
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:geographicElement/gmd:EX_GeographicDescription/gmd:geographicIdentifier/*[1]/gmd:code |
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:geographicElement/*[@gco:isoType='gmd:EX_GeographicDescription'][1]/gmd:geographicIdentifier/*[1]/gmd:code"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 16 - Vertical Extent Information                                             -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi16">
+    <sch:title>Vertical extent information</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi16-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:verticalElement/*[1]/gmd:minimumValue |
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:verticalElement/*[1]/gmd:maximumValue"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 17 - Spatial Reference System                                                -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi17">
+    <sch:title>Spatial reference system</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi17-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:referenceSystemInfo/*[1]/gmd:referenceSystemIdentifier/*[1]/gmd:code"
+    />
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi17-refSysInfo-1">
+    <sch:p>The coordinate reference system(s) used in the described dataset or dataset series shall
+      be given using element
+      gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier
+      INSPIRE Requirements metadata/2.0/req/sds-interoperable/crs and metadata/2.0/req/isdss/crs </sch:p>
+    <sch:rule context="//gmd:MD_Metadata[1]">
+      <sch:assert
+        test="count(//gmd:MD_Metadata[1]/child::gmd:referenceSystemInfo/descendant::gmd:RS_Identifier) &gt; 0"
+        > MI-17a (Spatial Reference System): At least one coordinate reference system used in the described dataset, dataset
+        series, or service shall be given using
+        gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi17-refSysInfo-3">
+    <sch:p>If the coordinate reference system is listed in the table Default Coordinate Reference
+      System Identifiers in Annex D.4, ... The gmd:codeSpace element shall not be used in this
+      case.</sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:referenceSystemInfo/*[1]/gmd:referenceSystemIdentifier/gmd:RS_Identifier[1]/gmd:code/gmx:Anchor[1]/@xlink:href">
+      <!-- associated test for whether code is a default CRS is in supplemental -->
+      <sch:report
+        test="
+          $defaultCRScodes//crs/text()[normalize-space(.) = normalize-space(current()/.)] and
+          count(parent::gmx:Anchor/parent::gmd:code/parent::gmd:RS_Identifier/child::gmd:codeSpace) &gt; 0"
+        > MI-17b (Spatial Reference System): The coordinate reference system <sch:value-of
+          select="normalize-space(current()/.)"/> is listed in Default Coordinate Reference System
+        Identifiers in Annex D.4. Such identifiers SHALL NOT use gmd:codeSpace </sch:report>
+    </sch:rule>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:referenceSystemInfo/*[1]/gmd:referenceSystemIdentifier/gmd:RS_Identifier[1]/gmd:code/gco:CharacterString">
+      <!-- associated test for whether code is a default CRS is in supplemental -->
+      <sch:report
+        test="
+          $defaultCRScodes//crs/text()[normalize-space(.) = normalize-space(current()/.)] and
+          count(parent::gmd:code/parent::gmd:RS_Identifier/child::gmd:codeSpace) &gt; 0"
+        > MI-17c (Spatial Reference System): The coordinate reference system <sch:value-of
+          select="normalize-space(current()/.)"/> is listed in Default Coordinate Reference System
+        Identifiers in Annex D.4. Such identifiers SHALL NOT use gmd:codeSpace </sch:report>
+    </sch:rule>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:referenceSystemInfo/*[1]/gmd:referenceSystemIdentifier/gmd:RS_Identifier[1]/gmd:code/gmx:Anchor">
+      <sch:report
+        test="
+          $defaultCRScodes//crs/text()[normalize-space(.) = normalize-space(current()/.)] and
+          count(parent::gmd:code/parent::gmd:RS_Identifier/child::gmd:codeSpace) &gt; 0"
+        > MI-17d (Spatial Reference System): The coordinate reference system <sch:value-of
+          select="normalize-space(current()/.)"/> is listed in Default Coordinate Reference System
+        Identifiers in Annex D.4. Such identifiers SHALL NOT use gmd:codeSpace </sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 18 - Spatial Resolution                                                      -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi18">
+    <sch:title>Spatial Resolution</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi18-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:spatialResolution/*[1]/gmd:distance"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 19 - Resource Locator                                                        -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi19">
+    <sch:title>Resource locator</sch:title>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:distributionInfo/*[1]/gmd:transferOptions/*[1]/gmd:onLine/*[1]">
+      <sch:assert
+        test="
+          count(gmd:linkage) = 0 or
+          (starts-with(normalize-space(gmd:linkage/*[1]), 'http://') or
+          starts-with(normalize-space(gmd:linkage/*[1]), 'https://') or
+          starts-with(normalize-space(gmd:linkage/*[1]), 'ftp://'))"
+        > MI-19 (Resource Locator): The value of resource locator does not appear to be a valid URL. It has a value of
+          '<sch:value-of select="gmd:linkage/*[1]"/>'. The URL must start with either http://,
+        https:// or ftp://. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi19-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:distributionInfo/*[1]/gmd:transferOptions/*[1]/gmd:onLine/*[1]/gmd:linkage"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 21 - Data Format (metadata/2.0/req/isdss/data-encoding)                      -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi21">
+    <sch:title>Data Format</sch:title>
+    <sch:p>The encoding and the storage or transmission format of the provided datasets or dataset
+      series shall be given using the gmd:distributionFormat/gmd:MD_Format element. The multiplicity
+      of this element is 1..*. </sch:p>
+    <sch:let name="MDFs"
+      value="count(//gmd:MD_Metadata[1]/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat/gmd:MD_Format)"/>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:distributionInfo/gmd:MD_Distribution">
+      <sch:report
+        test="($hierarchyLevelCLValue = 'dataset' or $hierarchyLevelCLValue = 'series') and ($MDFs &lt; 1)"
+        > MI-21a (Data Format): Datasets or dataset series must have at least one
+        gmd:distributionFormat/gmd:MD_Format We have <sch:value-of select="$MDFs"/>
+      </sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi21-versionNils">
+    <sch:p>If the version of the encoding is unknown or if the encoding is not versioned, the
+      gmd:version shall be left empty and the nil reason attribute shall be provided with either
+      value "unknown" or "inapplicable" correspondingly</sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat/gmd:MD_Format/gmd:version/*[1]">
+      <sch:report
+        test="
+          ($hierarchyLevelCLValue = 'dataset' or $hierarchyLevelCLValue = 'series') and
+          (normalize-space(.) = 'NotApplicable' or normalize-space(.) = 'Not Applicable' or
+          normalize-space(.) = 'Not entered' or normalize-space(.) = 'Not Entered' or
+          normalize-space(.) = 'Missing' or normalize-space(.) = 'missing' or
+          normalize-space(.) = 'Unknown' or normalize-space(.) = 'unknown')"
+        > MI-21b (Data Format): A value of <sch:value-of select="normalize-space(.)"/> is not expected here. If
+        the version of the encoding is not known, then use nilReason='unknown', otherwise if the
+        encoding is not versioned use nilReason='inapplicable', like: &lt;gmd:version
+        nilReason='unknown' /&gt; </sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi21-Name-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:distributionInfo/*[1]/gmd:distributionFormat/*[1]/gmd:name"/>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillableVersionPattern" id="Gemini2-mi21-Version-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:distributionInfo/*[1]/gmd:distributionFormat/*[1]/gmd:version"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 23 - Responsible Organisation                                                -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-23">
+    <sch:title>Responsible organisation</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]">
+      <sch:assert test="count(gmd:pointOfContact) &gt;= 1"> MI-23a (Responsible Organisation): Responsible organisation is
+        mandatory. At least one shall be provided. </sch:assert>
+    </sch:rule>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:pointOfContact">
+      <sch:assert test="count(@gco:nilReason) = 0"> MI-23b (Responsible Organisation): The value of responsible organisation
+        shall not be null. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="ResponsiblePartyPattern" id="Gemini2-mi23-ResponsibleParty">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:pointOfContact"/>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi23-OrganisationName-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:pointOfContact/*[1]/gmd:organisationName |
+      //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:pointOfContact/*[1]/gmd:contactInfo/*[1]/gmd:address/*[1]/gmd:electronicMailAddress"
+    />
+  </sch:pattern>
+  <sch:pattern is-a="IsoCodeListPattern" id="Gemini2-mi23-Role-CodeList">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:pointOfContact/*[1]/gmd:role/*[1]"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 24 - Frequency of Update                                                     -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi24">
+    <sch:title>Frequency of update</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="IsoCodeListPattern" id="Gemini2-mi24-CodeList">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:resourceMaintenance/*[1]/gmd:maintenanceAndUpdateFrequency/*[1]"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 25 - Limitations on Public Access                                            -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi25-LimitationsOnPublicAccess">
+    <sch:title>LimitationsOnPublicAccess codelist</sch:title>
+    <sch:p>We need metadata to have a gmx:Anchor linking to one of the LimitationsOnPublicAccess codelist values from: http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess</sch:p>
+    <sch:let name="LoPAurl" value="'http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/'"/>
+    <sch:let name="LoPAurlNum" value="count(//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints/gmx:Anchor/@xlink:href[contains(.,$LoPAurl)])"/>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]">
+      <sch:report test="$LoPAurlNum != 1">
+        MI-25c (Limitations on Public Access): There must be one (and only one) LimitationsOnPublicAccess code list value specified using a gmx:Anchor in gmd:otherConstraints.
+        We have <sch:value-of select="$LoPAurlNum"/>
+      </sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi25-OtherConstraints-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:resourceConstraints/*[1]/gmd:otherConstraints"
+    />
+  </sch:pattern>
+  <sch:pattern is-a="IsoCodeListPattern" id="Gemini2-mi25-AccessConstraints-CodeList">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:resourceConstraints/*[1]/gmd:accessConstraints/*[1]"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 26 - Use Constraints                                                         -->
+  <!-- ========================================================================================== -->
+  <sch:pattern is-a="IsoCodeListPattern" id="Gemini2-mi26-UseConstraints-CodeList">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:resourceConstraints/*[1]/gmd:useConstraints/*[1]"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 27 - Additional Information Source                                           -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi27">
+    <sch:title>Additional information source</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi27-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:supplementalInformation"/>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 30 - Metadata Date                                                           -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi30">
+    <sch:title>Metadata date</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi30-NotNillable">
+    <sch:param name="context" value="//gmd:MD_Metadata[1]/gmd:dateStamp/gco:Date"/>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 33 - Metadata Language                                                       -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi33">
+    <sch:title>Metadata language</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]">
+      <sch:assert test="count(gmd:language) = 1"> MI-33 (Metadata Language): Metadata language is mandatory. One shall
+        be provided. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="LanguagePattern" id="Gemini2-mi33-Language">
+    <sch:param name="context" value="//gmd:MD_Metadata[1]/gmd:language"/>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 35 - Metadata Point of Contact                                               -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi35">
+    <sch:title>Metadata point of contact</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:contact">
+      <sch:assert test="count(@gco:nilReason) = 0"> MI-35a (Metadata Point of Contact): The value of metadata point of contact
+        shall not be null. </sch:assert>
+      <sch:assert
+        test="count(parent::node()[gmd:contact/*[1]/gmd:role/*[1]/@codeListValue = 'pointOfContact']) >= 1"
+        > MI-35b (Metadata Point of Contact): At least one metadata point of contact shall have the role 'pointOfContact'.
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="ResponsiblePartyPattern" id="Gemini2-mi35-ResponsibleParty">
+    <sch:param name="context" value="//gmd:MD_Metadata[1]/gmd:contact"/>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi35-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:contact/*[1]/gmd:organisationName | //gmd:MD_Metadata[1]/gmd:contact/*[1]/gmd:contactInfo/*[1]/gmd:address/*[1]/gmd:electronicMailAddress"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 36 - (Unique) Resource Identifier                                            -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi36">
+    <sch:title>(Unique) Resource Identifier</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:citation/*[1]">
+      <sch:assert
+        test="
+          ((../../../../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'dataset' or
+          ../../../../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'series') and
+          count(gmd:identifier) &gt;= 1) or
+          (../../../../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'dataset' and
+          ../../../../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'series') or
+          count(../../../../gmd:hierarchyLevel) = 0"
+        > MI-36 (Unique) Resource Identifier: (Unique) Resource Identifier is mandatory for datasets and series. One or more
+        shall be provided. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- Ensure that (Unique) Resource Identifier has a value -->
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi36-Code-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:citation/*[1]/gmd:identifier/*[1]/gmd:code"
+    />
+  </sch:pattern>
+  <!-- Ensure that a code space value is provided if the element is encoded -->
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi36-CodeSpace-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:citation/*[1]/gmd:identifier/*[1]/gmd:codeSpace"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 37 - Spatial Data Service Type                                               -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi37">
+    <sch:title>Spatial data service type</sch:title>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/srv:SV_ServiceIdentification | /*[1]/gmd:identificationInfo[1]/*[@gco:isoType = 'srv:SV_ServiceIdentification'][1]">
+      <sch:assert
+        test="
+          (../../gmd:hierarchyLevel/*[1]/@codeListValue = 'service' and
+          count(srv:serviceType) = 1) or
+          ../../gmd:hierarchyLevel/*[1]/@codeListValue != 'service'"
+        > MI-37a (Spatial Data Service Type): If the resource type is service, one spatial data service type shall be provided. </sch:assert>
+      <sch:assert
+        test="
+          srv:serviceType/*[1] = 'discovery' or
+          srv:serviceType/*[1] = 'view' or
+          srv:serviceType/*[1] = 'download' or
+          srv:serviceType/*[1] = 'transformation' or
+          srv:serviceType/*[1] = 'invoke' or
+          srv:serviceType/*[1] = 'other'"
+        > MI-37b (Spatial Data Service Type): Service type shall be one of 'discovery', 'view', 'download', 'transformation',
+        'invoke' or 'other' following INSPIRE generic names. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi37-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:serviceType"/>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 38 - Coupled Resource                                                        -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi38">
+    <sch:title>Coupled resource</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:operatesOn">
+      <sch:assert test="count(@xlink:href) = 1"> MI-38 (Coupled Resource): Coupled resource shall be implemented by
+        reference using the xlink:href attribute. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 39 - Resource Type (aka 46 - Hierarchy Level)                                -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi39">
+    <sch:title>Resource type</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]">
+      <sch:assert test="count(gmd:hierarchyLevel) = 1"> MI-39a (Resource Type): Resource type is mandatory. One
+        shall be provided. </sch:assert>
+      <sch:assert
+        test="
+          gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'dataset' or
+          gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'series' or
+          gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'service'"
+        > MI-39b (Resource Type): Value of resource type shall be 'dataset', 'series' or 'service'. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="IsoCodeListPattern" id="Gemini2-mi39-CodeList">
+    <sch:param name="context" value="//gmd:MD_Metadata[1]/gmd:hierarchyLevel/*[1]"/>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 41 - Conformity                                                              -->
+  <!-- Explanation is a required element but can be empty                                         -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi41">
+    <sch:title>Conformity</sch:title>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi41-confResult">
+    <sch:rule context="//gmd:MD_Metadata[1]">
+      <sch:assert
+        test="count(gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult) &gt; 0"
+        > MI-41a (Conformity): There must be at least one gmd:DQ_ConformanceResult </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- We need tests that WHEN we have INSPIRE conformance sections they have correct content -->
+  <sch:pattern fpi="Gemini2-mi41-inspire1089">
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = 'Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services']">
+      <sch:let name="localPassPath"
+        value="parent::gmd:title/parent::gmd:CI_Citation/parent::gmd:specification/following-sibling::gmd:pass"/>
+      <sch:let name="localDatePath"
+        value="parent::gmd:title/following-sibling::gmd:date/gmd:CI_Date"/>
+      <sch:assert test="$localPassPath/gco:Boolean or $localPassPath/@gco:nilReason = 'unknown'">
+        MI-41b (Conformity): The pass value shall be true, false, or have a nil reason of 'unknown', in a
+        conformance statement for <sch:value-of select="$inspire1089"/>
+      </sch:assert>
+      <!-- Other dates (creation 2010-11-23, revision 2013-12-30) ref: http://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:02010R1089-20131230 -->
+      <!-- Publication date ref: https://inspire.ec.europa.eu/inspire-legislation/26 -->
+      <sch:assert test="$localDatePath/gmd:date/gco:Date[normalize-space(text()) = '2010-12-08']">
+        MI-41c (Conformity): The date reported shall be 2010-12-08 (date of publication), in a conformance
+        statement for <sch:value-of select="$inspire1089"/>
+      </sch:assert>
+      <sch:assert
+        test="$localDatePath/gmd:dateType/gmd:CI_DateTypeCode[@codeListValue = 'publication']">
+        MI-41d (Conformity): The dateTypeCode reported shall be publication, in a conformance statement for
+          <sch:value-of select="$inspire1089"/>
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi41-inspire1089x">
+    <sch:p>This test allows for the title to start with `COMMISSION REGULATION` but ss. it should be
+      'Commission Regulation'</sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = 'COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services']">
+      <sch:let name="localPassPath"
+        value="parent::gmd:title/parent::gmd:CI_Citation/parent::gmd:specification/following-sibling::gmd:pass"/>
+      <sch:let name="localDatePath"
+        value="parent::gmd:title/following-sibling::gmd:date/gmd:CI_Date"/>
+      <sch:assert test="$localPassPath/gco:Boolean or $localPassPath/@gco:nilReason = 'unknown'">
+        MI-41e (Conformity): The pass value shall be true, false, or have a nil reason of 'unknown', in a
+        conformance statement for <sch:value-of select="$inspire1089"/>
+      </sch:assert>
+      <!-- Other dates (creation 2010-11-23, revision 2013-12-30) ref: http://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:02010R1089-20131230 -->
+      <!-- Publication date ref: https://inspire.ec.europa.eu/inspire-legislation/26 -->
+      <sch:assert test="$localDatePath/gmd:date/gco:Date[normalize-space(text()) = '2010-12-08']">
+        MI-41f (Conformity): The date reported shall be 2010-12-08 (date of publication), in a conformance
+        statement for <sch:value-of select="$inspire1089"/>
+      </sch:assert>
+      <sch:assert
+        test="$localDatePath/gmd:dateType/gmd:CI_DateTypeCode[@codeListValue = 'publication']">
+        MI-41g (Conformity): The DateTypeCode reported shall be publication, in a conformance statement for
+          <sch:value-of select="$inspire1089"/>
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi41-inspire976">
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = 'Commission Regulation (EC) No 976/2009 of 19 October 2009 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards the Network Services']">
+      <sch:let name="localPassPath"
+        value="parent::gmd:title/parent::gmd:CI_Citation/parent::gmd:specification/following-sibling::gmd:pass"/>
+      <sch:let name="localDatePath"
+        value="parent::gmd:title/following-sibling::gmd:date/gmd:CI_Date"/>
+      <sch:assert test="$localPassPath/gco:Boolean or $localPassPath/@gco:nilReason = 'unknown'">
+        MI-41h (Conformity): The pass value shall be true, false, or have a nil reason of 'unknown', in a
+        conformance statement for <sch:value-of select="$inspire976"/>
+      </sch:assert>
+      <!-- Other dates (creation 2009-10-19, revision 2010-12-28) ref: http://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:02009R0976-20101228 -->
+      <!-- Publication date ref: https://inspire.ec.europa.eu/inspire-legislation/26 -->
+      <sch:assert test="$localDatePath/gmd:date/gco:Date[normalize-space(text()) = '2010-12-08']">
+        MI-41i (Conformity): The date reported shall be 2010-12-08 (date of publication), in a conformance
+        statement for <sch:value-of select="$inspire976"/>
+      </sch:assert>
+      <sch:assert
+        test="$localDatePath/gmd:dateType/gmd:CI_DateTypeCode[@codeListValue = 'publication']">
+        MI-41j (Conformity): The dateTypeCode reported shall be publication, in a conformance statement for
+          <sch:value-of select="$inspire976"/>
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi41-inspireConf-sv">
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode[@codeListValue = 'service']">
+      <sch:let name="count1089"
+        value="count(parent::gmd:level/parent::gmd:DQ_Scope/parent::gmd:scope/following-sibling::gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = $inspire1089])"/>
+      <sch:let name="count1089x"
+        value="count(parent::gmd:level/parent::gmd:DQ_Scope/parent::gmd:scope/following-sibling::gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = $inspire1089x])"/>
+      <sch:let name="count976"
+        value="count(parent::gmd:level/parent::gmd:DQ_Scope/parent::gmd:scope/following-sibling::gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = $inspire976])"/>
+      <sch:assert test="$count1089 &lt;= 1"> M1-41k (Conformity): A service record should have no more than one
+        Conformance report to [1089/2010] (counted <sch:value-of select="$count1089"/>) </sch:assert>
+      <sch:assert test="$count1089x &lt;= 1"> M1-41l (Conformity): A service record should have no more than one
+        Conformance report to [1089/2010] (counted <sch:value-of select="$count1089"/>) </sch:assert>
+      <sch:assert test="$count976 &lt;= 1"> M1-41m (Conformity): A service record should have no more than one
+        Conformance report to [976/2009] (counted <sch:value-of select="$count976"/>) </sch:assert>
+      <sch:report
+        test="
+          not(parent::gmd:level/parent::gmd:DQ_Scope/parent::gmd:scope/following-sibling::gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = $inspire1089]) and
+          not(parent::gmd:level/parent::gmd:DQ_Scope/parent::gmd:scope/following-sibling::gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = $inspire1089x]) and
+          not(parent::gmd:level/parent::gmd:DQ_Scope/parent::gmd:scope/following-sibling::gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = $inspire976])"
+        > M1-41n (Conformity): A service record should have a Conformance report to [976/2009] or [1089/2010]
+      </sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi41-inspireConf-dss">
+    <sch:rule
+      context="
+        //gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode[@codeListValue = 'dataset'] |
+        //gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode[@codeListValue = 'series']">
+      <sch:assert
+        test="
+          count(parent::gmd:level/parent::gmd:DQ_Scope/parent::gmd:scope/following-sibling::gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = $inspire1089]) = 1 or
+          count(parent::gmd:level/parent::gmd:DQ_Scope/parent::gmd:scope/following-sibling::gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][normalize-space(text()) = $inspire1089x]) = 1"
+        > MI-41o (Conformity): Datasets and series must provide a conformance report to [1089/2010]. The INSPIRE
+        rule tells us this must be the EXACT title of the regulation, which is: <sch:value-of
+          select="$inspire1089"/>
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi41-Explanation-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/*[1]/gmd:report/*[1]/gmd:result/*[1]/gmd:explanation"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 42 - Specification                                                           -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi42">
+    <sch:title>Specification</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-mi42-Title-NotNillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/*[1]/gmd:report/*[1]/gmd:result/*[1]/gmd:specification/*[1]/gmd:title"
+    />
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi42-Date-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/*[1]/gmd:report/*[1]/gmd:result/*[1]/gmd:specification/*[1]/gmd:date/*[1]/gmd:date"
+    />
+  </sch:pattern>
+  <sch:pattern is-a="IsoCodeListPattern" id="Gemini2-mi42-DateType-CodeList">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/*[1]/gmd:report/*[1]/gmd:result/*[1]/gmd:specification/*[1]/gmd:date/*[1]/gmd:date/*[1]/gmd:dateType/*[1]"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 43 - Equivalent scale                                                        -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi43">
+    <sch:title>Equivalent scale</sch:title>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNillablePattern" id="Gemini2-mi43-Nillable">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:spatialResolution/*[1]/gmd:equivalentScale/*[1]/gmd:denominator"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 44 - Geographic Bounding Box  (see MI 11, 12, 13, 14)                        -->
+  <!-- ========================================================================================== -->
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 47 - Hierarchy level name                                                    -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi47">
+    <sch:title>Hierarchy level name</sch:title>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi47-general">
+    <sch:p>Hierarchy level name is mandatory for dataset series and services, not required for
+      datasets</sch:p>
+    <sch:rule context="//gmd:MD_Metadata[1]">
+      <sch:let name="hierLevelNameCount" value="count(gmd:hierarchyLevelName)"/>
+      <sch:report
+        test="$hierLevelNameCount = 0 and ($hierarchyLevelCLValue = 'service' or $hierarchyLevelCLValue = 'series')"
+        > MI-47a (Hierarchy level name): Need at least one hierarchyLevelName have: <sch:value-of
+          select="$hierLevelNameCount"/>
+      </sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi47-services-restriction">
+    <sch:p>TG Requirement 3.1: metadata/2.0/req/sds/resource-type Additionally the name of the
+      hierarchy level shall be given using element gmd:hierarchyLevelName element with a Non-empty
+      Free Text Element containing the term "service" in the language of the metadata.</sch:p>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:hierarchyLevelName/*[1]">
+      <sch:let name="hierLevelcListVal" value="preceding::gmd:hierarchyLevel/*/@codeListValue"/>
+      <sch:let name="hierLevelNameText" value="descendant-or-self::text()"/>
+      <sch:report test="($hierLevelcListVal = 'service' and $hierLevelNameText != 'service')">
+        MI-47b (Hierarchy level name): Hierarchy level name for services must have value "service" </sch:report>
+      <sch:assert test="normalize-space(.)"> MI-47c: Hierarchy level name for services must have
+        value "service" </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 48 - Quality Scope                                                           -->
+  <!-- Also see AT 8                                                                              -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi48">
+    <sch:title>Quality Scope</sch:title>
+    <sch:rule context="//gmd:MD_Metadata[1]">
+      <sch:assert test="count(gmd:dataQualityInfo) &gt; 0"> MI-48a (Quality Scope): There must be at least one
+        gmd:dataQualityInfo </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi48-series">
+    <sch:p>TG Requirement 1.9: metadata/2.0/req/datasets-and-series/one-data-quality-element</sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:hierarchyLevel/gmd:MD_ScopeCode[@codeListValue = 'series']">
+      <sch:let name="dssDQ"
+        value="count(//gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode[@codeListValue = 'series'])"/>
+      <sch:assert test="$dssDQ = 1"> MI-48b (Quality Scope): There shall be exactly one
+        gmd:dataQualityInfo/gmd:DQ_DataQuality element scoped to the entire described dataset
+        series, but here we have <sch:value-of select="$dssDQ"/>
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi48-dataset">
+    <sch:p>TG Requirement 1.9: metadata/2.0/req/datasets-and-series/one-data-quality-element</sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:hierarchyLevel/gmd:MD_ScopeCode[@codeListValue = 'dataset']">
+      <sch:let name="dsDQ"
+        value="count(//gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode[@codeListValue = 'dataset'])"/>
+      <sch:assert test="$dsDQ = 1"> MI-48c (Quality Scope): There shall be exactly one
+        gmd:dataQualityInfo/gmd:DQ_DataQuality element scoped to the entire described dataset, but
+        here we have <sch:value-of select="$dsDQ"/>
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi48-service">
+    <sch:p>TG Requirement 3.8: metadata/2.0/req/sds/only-one-dq-element</sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:hierarchyLevel/gmd:MD_ScopeCode[@codeListValue = 'service']">
+      <sch:let name="svDQ"
+        value="count(//gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode[@codeListValue = 'service'])"/>
+      <sch:assert test="$svDQ = 1"> MI-48d (Quality Scope): There shall be exactly one
+        gmd:dataQualityInfo/gmd:DQ_DataQuality element scoped to the entire described service, but
+        here we have <sch:value-of select="$svDQ"/>
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-mi48-service-1">
+    <sch:p>The level shall be named using element
+      gmd:scope/gmd:DQ_Scope/gmd:levelDescription/gmd:MD_ScopeDescription/gmd:other element with a
+      Non-empty Free Text Element containing the term "service" in the language of the metadata.
+      (metadata/2.0/req/sds/only-one-dq-element)</sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode[@codeListValue = 'service']">
+      <sch:assert test="count(following::gmd:levelDescription) = 1"> MI-48e (Quality Scope): gmd:levelDescription is
+        missing ~ the level shall be named using element
+        gmd:scope/gmd:DQ_Scope/gmd:levelDescription/gmd:MD_ScopeDescription/gmd:other element with a
+        Non-empty Free Text Element containing the term "service" </sch:assert>
+      <sch:report
+        test="
+          following::gmd:levelDescription/gmd:MD_ScopeDescription/gmd:other/gco:CharacterString/text() != 'service' or
+          following::gmd:levelDescription/gmd:MD_ScopeDescription/gmd:other/gmx:Anchor/text() != 'service'"
+        > MI-48f (Quality Scope): Value (gmd:MD_ScopeDescription/gmd:other) should be "service" </sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 50 - Spatial representation type                                             -->
+  <!-- metadata/2.0/req/isdss/spatial-representation-type                                         -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="metadata/2.0/req/isdss/spatial-representation-type">
+    <sch:title>Spatial Representation Type</sch:title>
+    <sch:p>Dataset and dataset series must have a MD_SpatialRepresentationTypeCode</sch:p>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/gmd:MD_DataIdentification[1]">
+      <sch:assert
+        test="($hierarchyLevelCLValue = 'dataset' or $hierarchyLevelCLValue = 'series') and count(gmd:spatialRepresentationType) &gt; 0"
+        > MI-50a (Spatial representation type): Dataset and dataset series metadata must have at least one
+        gmd:spatialRepresentationType with gmd:MD_SpatialRepresentationTypeCode. The codeListValue
+        must be one of 'vector', 'grid', 'tin', or 'textTable' </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="metadata/2.0/req/isdss/spatial-representation-type-values">
+    <sch:p>MD_SpatialRepresentationTypeCode, ... must be one of 'vector', 'grid', 'tin', or
+      'textTable'</sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/gmd:MD_DataIdentification[1]/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode">
+      <sch:assert
+        test="
+          ($hierarchyLevelCLValue = 'dataset' or $hierarchyLevelCLValue = 'series') and
+          (@codeListValue = 'vector' or @codeListValue = 'grid' or @codeListValue = 'tin' or @codeListValue = 'textTable')"
+        > MI-50b (Spatial representation type): codeListValue must be one of 'vector', 'grid', 'tin', or 'textTable' </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="metadata/2.0/req/isdss/spatial-representation-typeNN">
+    <sch:title>Spatial Representation Type is not nillable for dataset/series</sch:title>
+    <sch:p>Dataset and dataset series must have a MD_SpatialRepresentationTypeCode</sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/gmd:MD_DataIdentification[1]/gmd:spatialRepresentationType">
+      <sch:assert
+        test="($hierarchyLevelCLValue = 'dataset' or $hierarchyLevelCLValue = 'series') and count(gmd:MD_SpatialRepresentationTypeCode) &gt; 0"
+        > MI-50c (Spatial representation type): Dataset and dataset series metadata must have at least one
+        gmd:spatialRepresentationType with gmd:MD_SpatialRepresentationTypeCode. The codeListValue
+        must be one of 'vector', 'grid', 'tin', or 'textTable' </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="IsoCodeListPattern" id="Gemini2-mi50-SRType-CodeList">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 51 - Character encoding                                                      -->
+  <!-- metadata/2.0/req/isdss/character-encoding                                                  -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-mi51">
+    <sch:title>Character encoding</sch:title>
+    <sch:p>The character encoding(s) shall be given for datasets and datasets series which use
+      encodings not based on UTF-8 by using element gmd:characterSet/gmd:MD_CharacterSetCode
+      referring to one of the values of ISO 19139 code list MD_CharacterSetCode.</sch:p>
+    <sch:p>The multiplicity of this element is 0..n. If more than one character encoding is used
+      within the described dataset or datasets series, all used character encodings, including UTF-8
+      (code list value "utf8"), shall be given using this element</sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:characterSet/gmd:MD_CharacterSetCode[1]/@codeListValue">
+      <sch:assert
+        test="
+          ($hierarchyLevelCLValue = 'dataset' or $hierarchyLevelCLValue = 'series') and
+          $charSetCodes//gml:identifier/text()[normalize-space(.) = normalize-space(current()/.)]"
+        > MI-51 (Character encoding): "<sch:value-of select="normalize-space(.)"/>" is not one of the values of ISO 19139
+        code list MD_CharacterSetCode </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="IsoCodeListPattern" id="Gemini2-mi51-CharSet-CodeList">
+    <sch:param name="context"
+      value="//gmd:MD_Metadata/gmd:identificationInfo[1]/gmd:MD_DataIdentification/gmd:characterSet/gmd:MD_CharacterSetCode"
+    />
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Metadata Item 52 - Topological consistency                                                 -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="metadata/2.0/req/isdss/topological-consistency-quantitative-results">
+    <sch:p>When we have a DQ_QuantitativeResult for a gmd:DQ_TopologicalConsistency report, the
+      result type shall be declared using the xsi:type attribute of the gco:Record element </sch:p>
+    <sch:rule
+      context="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_TopologicalConsistency/gmd:result/gmd:DQ_QuantitativeResult/gmd:value">
+      <sch:assert test="count(gco:Record/@xsi:type) = 1"> MI-52a (Topological consistency): The result type shall be declared
+        using the xsi:type attribute of the gco:Record element </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="metadata/2.0/req/isdss/topological-consistency-descriptive-results">
+    <sch:title>Topological consistency</sch:title>
+    <sch:p>In the event that a Topological consistency report is required for a Generic Network
+      Model dataset, check that the correct date/datetype and boolean values are given. Test relies
+      on the citation having the required title...</sch:p>
+    <sch:let name="GenericNetworkModelValue"
+      value="'INSPIRE Data Specifications - Base Models - Generic Network Model'"/>
+    <sch:let name="GenericNetworkModelDate" value="'2013-04-05'"/>
+    <sch:rule
+      context="//gmd:DQ_TopologicalConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gco:CharacterString[normalize-space(text()) = 'INSPIRE Data Specifications - Base Models - Generic Network Model']">
+      <sch:report test="following::gmd:date/gmd:CI_Date/gmd:date/gco:Date[text() != '2013-04-05']">
+        MI-52b (Topological consistency): When TopologicalConsistency is for <sch:value-of select="$GenericNetworkModelValue"
+        />, the date given shall be the date of publication of the Generic Network Model, which is
+        2013-04-05 </sch:report>
+      <sch:report
+        test="following::gmd:dateType/gmd:CI_DateTypeCode[@codeListValue != 'publication']"> MI-52c (Topological consistency):
+        When TopologicalConsistency is for <sch:value-of select="$GenericNetworkModelValue"/>, the
+        code list value shall always be publication </sch:report>
+      <!-- explanation is needed, empty free text is caught elsewhere and gmd:explanation is required by schema -->
+      <sch:assert test="count(following::gmd:explanation/@gco:nilReason) = 0"> MI-52d (Topological consistency): When
+        TopologicalConsistency is for <sch:value-of select="$GenericNetworkModelValue"/>, Some
+        statement on topological consistency must be provided in the explanation</sch:assert>
+      <sch:assert test="following::gmd:pass/gco:Boolean = 'false'"> MI-52e (Topological consistency): When
+        TopologicalConsistency is for <sch:value-of select="$GenericNetworkModelValue"/>, The value
+        shall always be false to indicate that the data does not assure the centerline topology for
+        the network </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Ancillary Tests                                                                            -->
+  <!-- ========================================================================================== -->
+  <sch:pattern fpi="Gemini2-at1">
+    <sch:title>Data identification citation</sch:title>
+    <sch:p>The identification information citation cannot be null.</sch:p>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:citation">
+      <sch:assert test="count(@gco:nilReason) = 0"> AT-1: Identification information citation shall
+        not be null. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-at2">
+    <sch:title>Metadata resource type test</sch:title>
+    <sch:p>Test to ensure that metadata about datasets include the gmd:MD_DataIdentification element
+      and metadata about services include the srv:SV_ServiceIdentification element</sch:p>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]">
+      <sch:assert
+        test="
+          ((../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'dataset' or
+          ../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'series') and
+          (local-name(*) = 'MD_DataIdentification' or */@gco:isoType = 'gmd:MD_DataIdentification')) or
+          (../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'dataset' and
+          ../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'series') or
+          count(../gmd:hierarchyLevel) = 0"
+        > AT-2a: The first identification information element shall be of type
+        gmd:MD_DataIdentification. </sch:assert>
+      <sch:assert
+        test="
+          ((../gmd:hierarchyLevel[1]/*[1]/@codeListValue = 'service') and
+          (local-name(*) = 'SV_ServiceIdentification' or */@gco:isoType = 'srv:SV_ServiceIdentification')) or
+          (../gmd:hierarchyLevel[1]/*[1]/@codeListValue != 'service') or
+          count(../gmd:hierarchyLevel) = 0"
+        > AT-2b: The first identification information element shall be of type
+        srv:SV_ServiceIdentification. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-at3">
+    <sch:title>Metadata file identifier</sch:title>
+    <sch:p>A file identifier is required</sch:p>
+    <sch:rule context="//gmd:MD_Metadata[1]">
+      <sch:assert test="count(gmd:fileIdentifier) = 1"> AT-3a: A metadata file identifier shall be
+        provided. Its value shall be a system generated GUID. </sch:assert>
+      <sch:report test="contains(gmd:fileIdentifier, '{') or contains(gmd:fileIdentifier, '}')">
+        AT-3b: File identifier shouldn't contain braces </sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern is-a="TypeNotNillablePattern" id="Gemini2-at3-NotNillable">
+    <sch:param name="context" value="//gmd:MD_Metadata[1]/gmd:fileIdentifier"/>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-at4">
+    <sch:title>Constraints</sch:title>
+    <sch:p>Constraints (Limitations on public access and use constraints) are required.</sch:p>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]">
+      <sch:assert test="count(gmd:resourceConstraints) &gt;= 1"> AT-4: Limitations on public access
+        and use constraints are required. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-at5">
+    <!-- metadata/2.0/req/common/max-1-date-of-creation -->
+    <sch:title>Creation date type</sch:title>
+    <sch:p>Constrain citation date type = creation to one occurrence.</sch:p>
+    <sch:rule context="//gmd:CI_Citation | //*[@gco:isoType = 'gmd:CI_Citation'][1]">
+      <sch:assert test="count(gmd:date/*[1]/gmd:dateType/*[1][@codeListValue = 'creation']) &lt;= 1"
+        > AT-5: There shall not be more than one creation date. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-at6">
+    <sch:title>Non-empty free text content</sch:title>
+    <sch:p>Don't allow empty Free text gco:CharacterString or gmx:Anchor</sch:p>
+    <sch:rule context="//gco:CharacterString | //gmx:Anchor">
+      <sch:assert test="normalize-space(.)"> AT-6: Free text elements should not be empty
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="metadata/2.0/req/common/max-1-date-of-last-revision">
+    <sch:title>Revision date type</sch:title>
+    <sch:p>Constrain citation date type = revision to one occurrence.</sch:p>
+    <sch:rule context="//gmd:CI_Citation | //*[@gco:isoType = 'gmd:CI_Citation'][1]">
+      <sch:assert test="count(gmd:date/*[1]/gmd:dateType/*[1][@codeListValue = 'revision']) &lt;= 1"
+        > AT-7: There shall not be more than one revision date. </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern fpi="Gemini2-at8">
+    <sch:title>Legal Constraints</sch:title>
+    <sch:p>To satisfy INSPIRE TG Requirement C.18, there must be at least two gmd:resourceConstraints : md:MD_LegalConstraints element blocks
+      One for "Limitations on public access" and the other for "Conditions for access and use".  Applies to all metadata</sch:p>
+    <sch:rule context="//gmd:MD_Metadata[1]/gmd:identificationInfo">
+      <sch:let name="legalCons" value="count(//gmd:MD_Metadata[1]/gmd:identificationInfo/*[1]/gmd:resourceConstraints/gmd:MD_LegalConstraints)"/>
+      <sch:assert test="$legalCons &gt; 1">
+        AT-8: There must be at least two Legal Constraints sections (gmd:resourceConstraints/gmd:MD_LegalConstraints) in the metadata but we have <sch:value-of select="$legalCons"/>.  
+        One section shall be provided to describe the "Limitations on public access" and another shall be provided to describe the 
+        "Conditions for access and use"
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- ========================================================================================== -->
+  <!-- Abstract Patterns                                                                          -->
+  <!-- ========================================================================================== -->
+  <!-- Test that an element has a value or has a valid nilReason value -->
+  <sch:pattern abstract="true" id="TypeNillablePattern">
+    <sch:rule context="$context">
+      <sch:assert
+        test="
+          (string-length(normalize-space(.)) &gt; 0) or
+          (@gco:nilReason = 'inapplicable' or
+          @gco:nilReason = 'missing' or
+          @gco:nilReason = 'template' or
+          @gco:nilReason = 'unknown' or
+          @gco:nilReason = 'withheld' or
+          starts-with(@gco:nilReason, 'other:'))"
+        > AP-1a: The <sch:name/> element shall have a value or a valid Nil Reason. This test may be called by the 
+        following Metadata Items: 2 - Alternative Title, 36 - (Unique) Resource Identifier,
+        37 - Spatial Data Service Type 41 - Conformity, 42 - Specification, and 43 - Equivalent
+        scale </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern abstract="true" id="TypeNillableVersionPattern">
+    <sch:rule context="$context">
+      <sch:assert
+        test="
+          (string-length(normalize-space(.)) &gt; 0) or
+          (@gco:nilReason = 'inapplicable' or @gco:nilReason = 'unknown')"
+        > AP-1b: The <sch:name/> element shall have a value OR a nil reason of either 'inapplicable'
+        or 'unknown'. This test may be called by the following Metadata Items: 21 - Data Format</sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- Test that an element has a value - the value is not nillable -->
+  <sch:pattern abstract="true" id="TypeNotNillablePattern">
+    <sch:rule context="$context">
+      <sch:assert test="string-length(.) &gt; 0 and count(./@gco:nilReason) = 0"> AP-2: The
+        <sch:name/> element is not nillable and shall have a value. This test may be called by the following 
+        Metadata Items: 1 - Title, 4 - Abstract, 6 - Keyword, 11, 12, 13, 14 - Geographic Bounding
+        Box, 17 - Spatial Reference System, 23 - Responsible Organisation, 30 - Metadata Date, 35 -
+        Metadata Point of Contact, 36 - (Unique) Resource Identifier, 42 - Specification, and in the
+        Ancillary test 3 - Metadata file identifier </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- Test ISO code lists -->
+  <sch:pattern abstract="true" id="IsoCodeListPattern">
+    <sch:rule context="$context">
+      <sch:assert test="string-length(@codeListValue) &gt; 0"> AP-3: The codeListValue attribute
+        does not have a value. This test may be called by the following Metadata Items: 6 - Keyword, 8 -
+        Dataset Reference Date, 23 - Responsible Organisation, 24 - Frequency of Update, 25 -
+        Limitations on Public Access, 26 - Use Constraints, 39 - Resource Type (aka 46 - Hierarchy Level), 42 -
+        Specification, 50 - Spatial representation type, and 51 - Character encoding </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- Test the language values (Metadata and Resource) -->
+  <sch:pattern abstract="true" id="LanguagePattern">
+    <sch:rule context="$context">
+      <sch:assert test="count(gmd:LanguageCode) = 1"> AP-4a: Language shall be implemented with
+        gmd:LanguageCode. <sch:value-of select="$LPreportsupplement"/>
+      </sch:assert>
+    </sch:rule>
+    <sch:rule context="$context/gmd:LanguageCode">
+      <sch:assert test="string-length(@codeListValue) &gt; 0"> AP-4b: The language code list value
+        is absent. When a dataset has no natural language use code zxx. <sch:value-of
+          select="$LPreportsupplement"/>
+      </sch:assert>
+      <sch:report test="string-length(@codeListValue) != 3"> AP-4c: The language code should be
+        three characters. <sch:value-of select="$LPreportsupplement"/>
+      </sch:report>
+    </sch:rule>
+  </sch:pattern>
+  <!-- Test for the responsible party information -->
+  <sch:pattern abstract="true" id="ResponsiblePartyPattern">
+    <!-- Count of Organisation Name and Individual Name >= 1 -->
+    <sch:rule context="$context">
+      <sch:assert test="count(*/gmd:organisationName) = 1"> AP-5a: One organisation name shall be
+        provided. <sch:value-of select="$RPreportsupplement"/>
+      </sch:assert>
+      <sch:assert
+        test="count(*/gmd:contactInfo/*[1]/gmd:address/*[1]/gmd:electronicMailAddress) = 1"> AP-5b:
+        One email address shall be provided. <sch:value-of select="$RPreportsupplement"/>
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <!-- Test for gmd:MD_GeographicBoundingBox values -->
+  <sch:pattern abstract="true" id="GeographicBoundingBoxPattern">
+    <sch:rule context="$context">
+      <!-- West Bound Longitude -->
+      <sch:assert
+        test="string-length(gmd:westBoundLongitude) = 0 or (gmd:westBoundLongitude &gt;= -180.0 and gmd:westBoundLongitude &lt;= 180.0)"
+        > AP-6a: West bound longitude has a value of <sch:value-of select="gmd:westBoundLongitude"/>
+        which is outside bounds. <sch:value-of select="$GBreportsupplement"/></sch:assert>
+      <!-- East Bound Longitude -->
+      <sch:assert
+        test="string-length(gmd:eastBoundLongitude) = 0 or (gmd:eastBoundLongitude &gt;= -180.0 and gmd:eastBoundLongitude &lt;= 180.0)"
+        >AP-6b: East bound longitude has a value of <sch:value-of select="gmd:eastBoundLongitude"/>
+        which is outside bounds. <sch:value-of select="$GBreportsupplement"/></sch:assert>
+      <!-- South Bound Latitude -->
+      <sch:assert
+        test="string-length(gmd:southBoundLatitude) = 0 or (gmd:southBoundLatitude &gt;= -90.0 and gmd:southBoundLatitude &lt;= gmd:northBoundLatitude)"
+        >AP-6c: South bound latitude has a value of <sch:value-of select="gmd:southBoundLatitude"/>
+        which is outside bounds. <sch:value-of select="$GBreportsupplement"/></sch:assert>
+      <!-- North Bound Latitude -->
+      <sch:assert
+        test="string-length(gmd:northBoundLatitude) = 0 or (gmd:northBoundLatitude &lt;= 90.0 and gmd:northBoundLatitude &gt;= gmd:southBoundLatitude)"
+        >AP-6d: North bound latitude has a value of <sch:value-of select="gmd:northBoundLatitude"/>
+        which is outside bounds. <sch:value-of select="$GBreportsupplement"/></sch:assert>
+    </sch:rule>
+  </sch:pattern>
+</sch:schema>

--- a/ckanext/spatial/validation/xml/gemini2/GEMINI_2.3_supplemental-v1.0.sch
+++ b/ckanext/spatial/validation/xml/gemini2/GEMINI_2.3_supplemental-v1.0.sch
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt" schemaVersion="1.2">
+    <sch:title>UK GEMINI Standard Draft Version 2.3 (supplemental)</sch:title>
+    <!-- Namespaces from ISO 19139 Metadata encoding -->
+    <sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+    <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+    <sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
+    <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+    <!-- Namespace for ISO 19119 - Metadata Describing Services -->
+    <sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
+    <!-- Namespace for ISO 19136 - Geography Mark-up Language -->
+    <sch:ns prefix="gml" uri="http://www.opengis.net/gml/3.2"/>
+    <!-- Namespace for CSW responses -->
+    <sch:ns prefix="csw" uri="http://www.opengis.net/cat/csw/2.0.2"/>
+    <!-- Namespace other -->
+    <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+    <sch:ns uri="http://www.isotc211.org/2005/gss" prefix="gss"/>
+    <sch:ns uri="http://www.isotc211.org/2005/gts" prefix="gts"/>
+    <sch:ns uri="http://www.isotc211.org/2005/gsr" prefix="gsr"/>
+    <sch:p>This Schematron schema is designed to show metadata recommendations for the GEMINI2 discovery metadata standard.</sch:p>
+    <!-- External document(s) -->
+    <sch:let name="defaultCRScodes" value="document('https://agi.org.uk/images/xslt/d4.xml')" />
+    <!-- IR titles -->
+    <sch:let name="inspire1089" value="'Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services'"/>
+    <sch:let name="inspire1089x" value="'COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services'"/>
+    <!-- ========================================================================================== -->
+    <sch:pattern fpi="metadata/2.0/rec/datasets-and-series/resource-locator-additional-info">
+        <sch:title>Resource Locator ~ additional information</sch:title>
+        <sch:p>Provide recommendation about providing additional information for transfer options
+            for online linkages applies to all metadata types.</sch:p>
+        <!-- The gmd:name, gmd:description, and gmd:function/gmd:CI_OnLineFunctionCode child elements of gmd:CI_OnlineResource element containing the given gmd:linkage element should also be provided -->
+        <sch:rule
+            context="//gmd:MD_Metadata[1]/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource">
+            <sch:assert test="gmd:name">SP-1a: If possible a gmd:name should be supplied to provide more
+                information about the URL link </sch:assert>
+            <sch:assert test="gmd:description">SP-1b: If possible a gmd:description should be supplied to
+                provide more information about the URL link </sch:assert>
+            <sch:assert test="gmd:function">SP-1c: If possible a gmd:function should be supplied to
+                provide more information about the URL link </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <!-- fpi="metadata/2.0/req/isdss/topological-consistency-descriptive-results-warn" has been removed. This was SP-2 -->
+    <sch:pattern fpi="Gemini2-mi3-rec">
+        <sch:title>Dataset language (recommendation)</sch:title>
+        <sch:p>TG rec 1.7 ~ Specifies use of language name over code</sch:p>
+        <sch:rule
+            context="//gmd:MD_Metadata[1]/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:language/gmd:LanguageCode">
+            <sch:report test="@codeListValue = current()">SP-3: You have the same text value as the
+                codeListValue, recommendation is to have the name of the language as the human
+                readable text </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern fpi="Gemini2-mi17-refSysInfo-recs">
+        <sch:title>Coordinate Reference System (warning)</sch:title>
+        <sch:p>Checking whether coordinate reference system is a default CRS</sch:p>
+        <sch:rule
+            context="//gmd:MD_Metadata[1]/gmd:referenceSystemInfo/*[1]/gmd:referenceSystemIdentifier/gmd:RS_Identifier[1]/gmd:code/gmx:Anchor[1]/@xlink:href">
+            <sch:assert
+                test="$defaultCRScodes//crs/text()[normalize-space(.) = normalize-space(current()/.)]"
+                >SP-4a: Coordinate Reference System: <sch:value-of
+                    select="normalize-space(current()/.)"/> is not a default CRS </sch:assert>
+        </sch:rule>
+        <sch:rule
+            context="//gmd:MD_Metadata[1]/gmd:referenceSystemInfo/*[1]/gmd:referenceSystemIdentifier/gmd:RS_Identifier[1]/gmd:code/gco:CharacterString">
+            <sch:assert
+                test="$defaultCRScodes//crs/text()[normalize-space(.) = normalize-space(current()/.)]"
+                >SP-4b: Coordinate Reference System: <sch:value-of
+                    select="normalize-space(current()/.)"/> is not a default CRS </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern fpi="Gemini2-mi41-inspire1089x-WARN">
+        <sch:title>1089/2010 Case (warning)</sch:title>
+        <sch:p>This test checks for the title starting with `COMMISSION REGULATION` as ss. it should be 'Commission Regulation'...</sch:p>
+        <sch:rule context="//gmd:MD_Metadata[1]/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/*[1][text() = 'COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services']">
+            <sch:report test=".">SP-5:
+                To be fully compliant with the regulation the title should be <sch:value-of select="$inspire1089"/>. 
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+</sch:schema>

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,3 +12,4 @@ pyasn1==0.4.4
 pyOpenSSL==18.0.0
 urllib3==1.23
 enum34==1.1.6
+freezegun==0.3.12


### PR DESCRIPTION
## What

In order to validate gemini 2.3 documents the gemini 2.3 schematron has been extracted from the zip file located - https://www.agi.org.uk/about/resources/category/125-schematron

In addition to adding the new schematron, validation tests in `test_harvest.py` have been fixed in order to allow testing of the different configuration options in order to link a document to gemini 2.3 and allow the system to use config supplied by the user.

Starting from December 2019 there will be a warning message for users who have harvest sources still using gemini 2. 

## How to test

At the moment in order to test the gemini 2.3 validation this must be entered for the harvest source config - `{"validator_profiles": ["iso19139eden", "constraints-1.4", "gemini2-3"]}`, otherwise the system will default to gemini2-1.3

## Reference 

https://trello.com/c/8O2KPwpe/1061-check-harvesters-support-new-gemini-standard-23