### PR TITLE
Update gen_new_name to handle > 100 duplicates

### DIFF
--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -15,6 +15,7 @@ from numbers import Number
 import uuid
 import logging
 import difflib
+import re
 
 from lxml import etree
 from sqlalchemy.sql import update, bindparam
@@ -412,18 +413,34 @@ class GeminiHarvester(SpatialHarvester):
         name = munge_title_to_name(title).replace('_', '-')
         while '--' in name:
             name = name.replace('--', '-')
-        like_q = u'%s%%' % name
-        pkg_query = Session.query(Package).filter(Package.name.ilike(like_q)).limit(100)
-        taken = [pkg.name for pkg in pkg_query]
-        if name not in taken:
-            return name
-        else:
-            counter = 1
-            while counter < 101:
-                if name+str(counter) not in taken:
-                    return name+str(counter)
+        like_q = "{}%".format(name)
+
+        pkg_query = Session.query(
+            Package
+        ).filter(
+            Package.name.ilike(like_q)
+        ).order_by(
+            Package.metadata_created.desc()
+        ).first()
+
+        if pkg_query:
+            match = re.match(r"\D+(\d+)$", pkg_query.name)
+            counter = int(match.group(1)) if match else 0
+
+            while True:
                 counter = counter + 1
-            return None
+                new_name = name + str(counter)
+
+                have_name = Session.query(
+                    Package
+                ).filter(
+                    Package.name.ilike(new_name)
+                ).first()
+
+                if not have_name:
+                    return new_name
+
+        return name
 
     @classmethod
     def _extract_first_licence_url(self, licences):
@@ -615,7 +632,6 @@ class GeminiCswHarvester(GeminiHarvester, SingletonPlugin):
             # Contents come from csw_client already declared and encoded as utf-8
             # Remove original XML declaration
             # (copied from csw.py:179
-            import re
 
             content = re.sub('<\?xml(.*)\?>', '', record['xml'])
 

--- a/ckanext/spatial/tests/unit/harvesters/test_gemini.py
+++ b/ckanext/spatial/tests/unit/harvesters/test_gemini.py
@@ -3,7 +3,7 @@ from mock import call, patch, Mock
 
 from nose.tools import assert_raises
 
-from ckanext.spatial.harvesters.gemini import GeminiWafHarvester
+from ckanext.spatial.harvesters.gemini import GeminiWafHarvester, GeminiHarvester
 
 
 @patch('ckanext.spatial.harvesters.gemini.GeminiHarvester._save_gather_error')
@@ -28,3 +28,39 @@ def test_gemini_waf_extract_urls_report_link_errors(mock_save_gather_error):
             call('Ignoring link in WAF because it has "/": /xml/BoundaryLine.xml', gemini.harvest_job),
             call('Ignoring link in WAF because it has "/": /xml/SmallScale.xml', gemini.harvest_job)
         ]
+
+
+@patch('ckan.model.Session.query')
+def test_gen_new_name(mock_ckan_session_query):
+    class MockSessionQuery:
+        def __init__(self, name):
+            self.name = name
+            self.first_query = True
+
+        def filter(self, *arg):
+            mock_return = Mock()
+            if self.first_query:
+                self.first_query = False
+
+                if self.name:
+                    mock_pkg_query = Mock()
+                    mock_pkg_query.name = self.name
+                else:
+                    mock_pkg_query = None
+                mock_return.order_by.return_value.first.return_value = mock_pkg_query
+                return mock_return
+            else:
+                mock_return = Mock()
+                mock_return.first.return_value = None
+                return mock_return
+
+    harvester = GeminiHarvester()
+
+    mock_ckan_session_query.return_value = MockSessionQuery(None)
+    assert harvester.gen_new_name('Some test') == 'some-test'
+
+    mock_ckan_session_query.return_value = MockSessionQuery('some-test')
+    assert harvester.gen_new_name('Some test') == 'some-test1'
+
+    mock_ckan_session_query.return_value = MockSessionQuery('some-test100')
+    assert harvester.gen_new_name('Some test') == 'some-test101'


### PR DESCRIPTION
## What 

Existing code only handles up to 100 but there are datasets which have more than 100 of the same name, this causes any new datasets with the same name to be incorrectly labelled as being in use.

This also fixes the counter order as it was retrieving the first 100 ordered by package name which left out xxx90 in favour of xxx100 which also lead to some confusion.

## Reference 

https://trello.com/c/7prmDou5/1082-that-url-is-already-in-use-error-message-when-reharvesting