### PR TITLE
Upgrade OWS lib to latest version

### DIFF
--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -154,9 +154,7 @@ class GeminiHarvester(SpatialHarvester):
         if last_harvested_object:
             # We've previously harvested this (i.e. it's an update)
 
-            # sets harvest_object.force_import property to self.force_import when set
-            if hasattr(harvest_object, 'force_import'):
-                self.force_import = harvest_object.force_import
+            self.force_import = getattr(harvest_object, 'force_import', False)
 
             # Use metadata modified date instead of content to determine if the package
             # needs to be updated

--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -300,8 +300,7 @@ class GeminiHarvester(SpatialHarvester):
                     resource = {}
                     if extras['resource-type'] == 'service':
                         # Check if the service is a view service
-                        test_url = url.split('?')[0] if '?' in url else url
-                        if self._is_wms(test_url):
+                        if self._is_wms(url):
                             resource['verified'] = True
                             resource['verified_date'] = datetime.now().isoformat()
                             resource_format = 'WMS'

--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -154,6 +154,10 @@ class GeminiHarvester(SpatialHarvester):
         if last_harvested_object:
             # We've previously harvested this (i.e. it's an update)
 
+            # sets harvest_object.force_import property to self.force_import when set
+            if hasattr(harvest_object, 'force_import'):
+                self.force_import = harvest_object.force_import
+
             # Use metadata modified date instead of content to determine if the package
             # needs to be updated
             if last_harvested_object.metadata_modified_date is None \

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,7 +1,7 @@
 GeoAlchemy>=0.6
 GeoAlchemy2==0.5.0
 Shapely>=1.2.13
-OWSLib==0.8.6
+OWSLib==0.18.0
 lxml>=2.3
 argparse
 pyparsing>=2.1.10


### PR DESCRIPTION
## What

Some of the processing of WMS URLs were failing because the OWS library was unable to handle the content. This upgrade fixes bugs in OWS to ensure that spatial can support the latest WMS schemas.