### PR TITLE
Propogate error message from OWSLib wms to user

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -665,7 +665,7 @@ class SpatialHarvester(HarvesterBase):
         return True
     ##
 
-    def _is_wms(self, url):
+    def _is_wms(self, url, harvest_object=None):
         '''
         Checks if the provided URL actually points to a Web Map Service.
         '''
@@ -678,7 +678,11 @@ class SpatialHarvester(HarvesterBase):
             s = wms.WebMapService(url, xml=xml, version=None if not version else version[0])
             return isinstance(s.contents, dict) and s.contents != {}
         except Exception, e:
-            log.error('WMS check for %s failed with exception: %s' % (url, str(e)))
+            message = 'WMS check for %s failed with exception: %s' % (url, str(e))
+            if harvest_object:
+                self._save_object_error(message, harvest_object, 'Import')
+            else:
+                log.error(message)
         return False
 
     def _get_object_extra(self, harvest_object, key):

--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -302,7 +302,7 @@ class GeminiHarvester(SpatialHarvester):
                     resource = {}
                     if extras['resource-type'] == 'service':
                         # Check if the service is a view service
-                        if self._is_wms(url):
+                        if self._is_wms(url, harvest_object=harvest_object):
                             resource['verified'] = True
                             resource['verified_date'] = datetime.now().isoformat()
                             resource_format = 'WMS'


### PR DESCRIPTION
## What

Map previews links were not being shown but Users had no idea why, by reporting the error message back to users this should help them investigate issues to do with their servers if that is the case rather than the team investigating an issue linked to their data source.

## Why

Making errors more visible will help User fix problems on their end and reduce support tickets.

## Reference 

https://trello.com/c/QzELjbIB/1310-investigate-why-the-format-for-some-spatial-datasets-are-not-populated-and-fix-it