### PR TITLE
Update xpath for WMS version

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -674,7 +674,7 @@ class SpatialHarvester(HarvesterBase):
             # identify the version first otherwise OWSLib will default to 1.1.1
             xml = self._get_content(url)
             doc = lxml.html.fromstring(xml)
-            version = doc.xpath("./@version")
+            version = doc.xpath("//@version")
             s = wms.WebMapService(url, xml=xml, version=None if not version else version[0])
             return isinstance(s.contents, dict) and s.contents != {}
         except Exception, e:

--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -154,7 +154,7 @@ class GeminiHarvester(SpatialHarvester):
         if last_harvested_object:
             # We've previously harvested this (i.e. it's an update)
 
-            self.force_import = getattr(harvest_object, 'force_import', False)
+            self.force_import = self.force_import or getattr(harvest_object, 'force_import', False)
 
             # Use metadata modified date instead of content to determine if the package
             # needs to be updated

--- a/ckanext/spatial/tests/test_harvest.py
+++ b/ckanext/spatial/tests/test_harvest.py
@@ -1,4 +1,6 @@
 import os
+from mock import patch, Mock
+import urllib2
 from datetime import datetime, date
 import lxml
 import json
@@ -1131,17 +1133,31 @@ class TestValidation(HarvestFixtureBase):
         assert len(errors) > 0
         assert_in('Could not get the GUID', errors)
 
-    def test_10_service_fail_constraints_schematron(self):
+    def mock_valid_wms(self, mock_get_content, mock_wms):
+        http_response = urllib2.urlopen('http://127.0.0.1:8999/gemini2.1/validation/valid_wms_1_3.xml')
+        mock_get_content.return_value = http_response.read()
+        mock_wms.return_value = Mock()
+
+    @patch('owslib.wms.WebMapService')
+    @patch('ckanext.spatial.harvesters.base.SpatialHarvester._get_content')
+    def test_10_service_fail_constraints_schematron(self, mock_get_content, mock_wms):
+        self.mock_valid_wms(mock_get_content, mock_wms)
         errors = self.get_validation_errors('10_Service_Invalid_19139_Level_Description.xml')
         assert len(errors) > 0
         assert_in("DQ_Scope: 'levelDescription' is mandatory if 'level' notEqual 'dataset' or 'series'.", errors)
 
-    def test_11_service_fail_gemini_schematron(self):
+    @patch('owslib.wms.WebMapService')
+    @patch('ckanext.spatial.harvesters.base.SpatialHarvester._get_content')
+    def test_11_service_fail_gemini_schematron(self, mock_get_content, mock_wms):
+        self.mock_valid_wms(mock_get_content, mock_wms)
         errors = self.get_validation_errors('11_Service_Invalid_GEMINI_Service_Type.xml')
         assert len(errors) > 0
         assert_in("Service type shall be one of 'discovery', 'view', 'download', 'transformation', 'invoke' or 'other' following INSPIRE generic names.", errors)
 
-    def test_12_service_valid(self):
+    @patch('owslib.wms.WebMapService')
+    @patch('ckanext.spatial.harvesters.base.SpatialHarvester._get_content')
+    def test_12_service_valid(self, mock_get_content, mock_wms):
+        self.mock_valid_wms(mock_get_content, mock_wms)
         errors = self.get_validation_errors('12_Service_Valid.xml')
         assert len(errors) == 0, errors
 
@@ -1157,8 +1173,11 @@ class TestValidation(HarvestFixtureBase):
         assert len(errors) > 0
         assert_in('gemini2/gemini2-1.3 will be deprecated, please use gemin2-3', errors)
 
+    @patch('owslib.wms.WebMapService')
+    @patch('ckanext.spatial.harvesters.base.SpatialHarvester._get_content')
     @freeze_time("2019-12-10T00:00:00")
-    def test_15_no_deprecation_message_for_gemini_2_3(self):
+    def test_15_no_deprecation_message_for_gemini_2_3(self, mock_get_content, mock_wms):
+        self.mock_valid_wms(mock_get_content, mock_wms)
         source_fixture = {
             'title': 'Test Source',
             'name': 'test-source',
@@ -1169,7 +1188,10 @@ class TestValidation(HarvestFixtureBase):
             'BGSsv-examplea1.xml', source_fixture=source_fixture, gemini_profile='gemini2-3')
         assert not errors
 
-    def test_16_gemini2_3_dataset_valid(self):
+    @patch('owslib.wms.WebMapService')
+    @patch('ckanext.spatial.harvesters.base.SpatialHarvester._get_content')
+    def test_16_gemini2_3_dataset_valid(self, mock_get_content, mock_wms):
+        self.mock_valid_wms(mock_get_content, mock_wms)
         source_fixture = {
             'title': 'Test Source',
             'name': 'test-source',

--- a/ckanext/spatial/tests/xml/gemini2.1/validation/14_Unsupported_version.xml
+++ b/ckanext/spatial/tests/xml/gemini2.1/validation/14_Unsupported_version.xml
@@ -1,0 +1,14 @@
+<?xml version=\'1.0\' encoding="ISO-8859-1" standalone="no" ?>
+<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://schemas.opengis.net/wms/1.1.0/capabilities_1_1_0.dtd"
+ [
+ <!ELEMENT VendorSpecificCapabilities EMPTY>
+ ]>
+
+
+<WMT_MS_Capabilities version="1.1.0">
+
+<Service>
+  <Name>OGC:WMS</Name>
+  <Title>Unsupported INSPIRE service</Title>
+</Service>
+</WMT_MS_Capabilities>

--- a/ckanext/spatial/tests/xml/gemini2.1/validation/valid_wms_1_3.xml
+++ b/ckanext/spatial/tests/xml/gemini2.1/validation/valid_wms_1_3.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0" xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd"/>


### PR DESCRIPTION
## What

Update it to use the root element to get the version attribute rather than the first element which might not be the root element.

Also fix the tests and add a test to show error messages from an unsupported WMS version.

## Reference 

https://trello.com/c/QzELjbIB/1310-5-investigate-why-the-format-for-some-spatial-datasets-are-not-populated-and-fix-it