### PR TITLE
Update ckan_pycsw.py to use pycsw 2.4.0

### DIFF
--- a/bin/ckan_pycsw.py
+++ b/bin/ckan_pycsw.py
@@ -6,9 +6,10 @@ import io
 import requests
 from lxml import etree
 
-from pycsw import metadata, repository, util
-import pycsw.config
-import pycsw.admin
+# use pycsw 2.4.0
+from pycsw.core import metadata, repository, util
+import pycsw.core.config
+import pycsw.core.admin
 
 logging.basicConfig(format='%(message)s', level=logging.INFO)
 
@@ -27,7 +28,7 @@ def setup_db(pycsw_config):
         Column('ckan_modified', Text),
     ]
 
-    pycsw.admin.setup_db(database,
+    pycsw.core.admin.setup_db(database,
         table_name, '',
         create_plpythonu_functions=False,
         extra_columns=ckan_columns)
@@ -58,7 +59,7 @@ def load(pycsw_config, ckan_url):
     database = pycsw_config.get('repository', 'database')
     table_name = pycsw_config.get('repository', 'table', 'records')
 
-    context = pycsw.config.StaticContext()
+    context = pycsw.core.config.StaticContext()
     repo = repository.Repository(database, context, table=table_name)
 
     log.info('Started gathering CKAN datasets identifiers: {0}'.format(str(datetime.datetime.now())))


### PR DESCRIPTION
## What

Update the code to work with pycsw 2.4.0 so that we can use OWSLib 0.18.0 which will update us to a later version of OWSLib as the current version being used is 5 years old and also provide a more meaningful error message to users when they attempt to use an unsupported WMS service.

Note -

This needs to be deployed with an update of dependencies in`ckanext-datagovuk` to use pycsw 2.4.0 as otherwise it will break csw data syncing. As this happens just once a day it's probably an acceptable risk.

## Reference

https://trello.com/c/QzELjbIB/1310-5-investigate-why-the-format-for-some-spatial-datasets-are-not-populated-and-fix-it