### PR TITLE
Fix check on guids without urls

### DIFF
--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -160,7 +160,7 @@ class GeminiHarvester(SpatialHarvester):
             existing_source_url = get_harvest_object_url(last_harvested_object.id)
             new_source_url = get_harvest_object_url(harvest_object.id)
 
-            if existing_source_url != new_source_url:
+            if existing_source_url and existing_source_url != new_source_url:
                 if last_harvested_object.package.state == u'deleted':
                     last_harvested_object.current = False
                     last_harvested_object.save()


### PR DESCRIPTION
## What

Data source urls were not captured before so its not possible to check if the source url has changed. For now we'll have to ignore the check for duplicate guids within a data source if the existing url doesn't have it stored.

If we don't ignore the duplicate guid checks then the existing harvest objects will throw errors.