### PR TITLE
Log all method calls to identify code paths

### DIFF
--- a/ckanext/spatial/commands/spatial.py
+++ b/ckanext/spatial/commands/spatial.py
@@ -2,12 +2,15 @@ import sys
 import re
 from pprint import pprint
 import logging
+from autologging import traced
 
 from ckan.lib.cli import CkanCommand
 from ckan.lib.helpers import json
 from ckanext.spatial.lib import save_package_extent
 log = logging.getLogger(__name__)
 
+
+@traced
 class Spatial(CkanCommand):
     '''Performs spatially related operations.
 
@@ -94,4 +97,3 @@ class Spatial(CkanCommand):
         msg = "Done. Extents generated for %i out of %i packages" % (count,len(packages))
 
         print msg
-

--- a/ckanext/spatial/controllers/api.py
+++ b/ckanext/spatial/controllers/api.py
@@ -1,4 +1,5 @@
 import logging
+from autologging import traced
 
 try:
     from cStringIO import StringIO
@@ -19,6 +20,7 @@ from ckanext.spatial.lib import get_srid, validate_bbox, bbox_query
 log = logging.getLogger(__name__)
 
 
+@traced
 class ApiController(BaseApiController):
 
     def spatial_query(self):
@@ -51,6 +53,7 @@ class ApiController(BaseApiController):
         return self._finish_ok(output)
 
 
+@traced
 class HarvestMetadataApiController(BaseApiController):
 
     def _get_content(self, id):
@@ -118,7 +121,7 @@ class HarvestMetadataApiController(BaseApiController):
 
         return xslt_package, xslt_path
 
-    def display_xml_original(self, id):
+    def display_xml_original(self, id, **kwargs):
         content = self._get_original_content(id)
 
         if not content:
@@ -131,7 +134,7 @@ class HarvestMetadataApiController(BaseApiController):
             content = u'<?xml version="1.0" encoding="UTF-8"?>\n' + content
         return content.encode('utf-8')
 
-    def display_html(self, id):
+    def display_html(self, id, **kwargs):
         content = self._get_content(id)
 
         if not content:
@@ -140,7 +143,7 @@ class HarvestMetadataApiController(BaseApiController):
         xslt_package, xslt_path = self._get_xslt()
         return self._transform_to_html(content, xslt_package, xslt_path)
 
-    def display_html_original(self, id):
+    def display_html_original(self, id, **kwargs):
         content = self._get_original_content(id)
 
         if content is None:

--- a/ckanext/spatial/harvesters/csw.py
+++ b/ckanext/spatial/harvesters/csw.py
@@ -3,6 +3,7 @@ import urllib
 import urlparse
 
 import logging
+from autologging import traced
 
 from ckan import model
 
@@ -16,6 +17,7 @@ from ckanext.spatial.lib.csw_client import CswService
 from ckanext.spatial.harvesters.base import SpatialHarvester, text_traceback
 
 
+@traced
 class CSWHarvester(SpatialHarvester, SingletonPlugin):
     '''
     A Harvester for CSW servers
@@ -192,4 +194,3 @@ class CSWHarvester(SpatialHarvester, SingletonPlugin):
 
     def _setup_csw_client(self, url):
         self.csw = CswService(url)
-

--- a/ckanext/spatial/harvesters/doc.py
+++ b/ckanext/spatial/harvesters/doc.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+from autologging import traced
 
 from ckan import model
 
@@ -12,6 +13,7 @@ from ckanext.harvest.model import HarvestObjectExtra as HOExtra
 from ckanext.spatial.harvesters.base import SpatialHarvester,  guess_standard
 
 
+@traced
 class DocHarvester(SpatialHarvester, SingletonPlugin):
     '''
     A Harvester for individual spatial metadata documents
@@ -110,4 +112,3 @@ class DocHarvester(SpatialHarvester, SingletonPlugin):
     def fetch_stage(self,harvest_object):
         # The fetching was already done in the previous stage
         return True
-

--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -14,6 +14,8 @@ from datetime import datetime
 from numbers import Number
 import uuid
 import logging
+from autologging import traced
+
 import difflib
 import re
 
@@ -46,6 +48,7 @@ log = logging.getLogger(__name__)
 debug_exception_mode = bool(os.getenv('DEBUG'))
 
 
+@traced
 class GeminiHarvester(SpatialHarvester):
     '''Base class for spatial harvesting GEMINI2 documents for the UK Location
     Programme. May be easily adaptable for other INSPIRE and spatial projects.
@@ -570,6 +573,7 @@ class GeminiHarvester(SpatialHarvester):
 
         return gemini_string, gemini_guid
 
+@traced
 class GeminiCswHarvester(GeminiHarvester, SingletonPlugin):
     '''
     A Harvester for CSW servers
@@ -679,6 +683,7 @@ class GeminiCswHarvester(GeminiHarvester, SingletonPlugin):
         self.csw = CswService(url)
 
 
+@traced
 class GeminiDocHarvester(GeminiHarvester, SingletonPlugin):
     '''
     A Harvester for individual GEMINI documents
@@ -740,6 +745,7 @@ class GeminiDocHarvester(GeminiHarvester, SingletonPlugin):
         return True
 
 
+@traced
 class GeminiWafHarvester(GeminiHarvester, SingletonPlugin):
     '''
     A Harvester from a WAF server containing GEMINI documents.

--- a/ckanext/spatial/harvesters/waf.py
+++ b/ckanext/spatial/harvesters/waf.py
@@ -1,4 +1,6 @@
 import logging
+from autologging import traced
+
 import hashlib
 from urlparse import urljoin
 import dateutil.parser
@@ -22,6 +24,7 @@ from ckanext.spatial.harvesters.base import SpatialHarvester, guess_standard
 log = logging.getLogger(__name__)
 
 
+@traced
 class WAFHarvester(SpatialHarvester, SingletonPlugin):
     '''
     A Harvester for WAF (Web Accessible Folders) containing spatial metadata documents.
@@ -317,4 +320,3 @@ def _extract_waf(content, base_url, scraper, results = None, depth=0):
         results.append((urljoin(base_url, record.url), date))
 
     return results
-

--- a/ckanext/spatial/lib/csw_client.py
+++ b/ckanext/spatial/lib/csw_client.py
@@ -4,6 +4,7 @@ for convenience.
 """
 
 import logging
+from autologging import traced
 
 from owslib.etree import etree
 from owslib.fes import PropertyIsEqualTo, SortBy, SortProperty
@@ -13,6 +14,7 @@ log = logging.getLogger(__name__)
 class CswError(Exception):
     pass
 
+@traced
 class OwsService(object):
     def __init__(self, endpoint=None):
         if endpoint is not None:

--- a/ckanext/spatial/lib/report.py
+++ b/ckanext/spatial/lib/report.py
@@ -3,11 +3,15 @@ Library for creating reports that can be displayed easily in an HTML table
 and then saved as a CSV.
 '''
 
+from autologging import traced
+
 import datetime
 import csv
 try: from cStringIO import StringIO
 except ImportError: from StringIO import StringIO
 
+
+@traced
 class ReportTable(object):
     def __init__(self, column_names):
         assert isinstance(column_names, (list, tuple))
@@ -66,4 +70,3 @@ class ReportTable(object):
                 raise Exception("%s: %s, %s"%(e, row, row_formatted))
         csvout.seek(0)
         return csvout.read()
-        

--- a/ckanext/spatial/lib/reports.py
+++ b/ckanext/spatial/lib/reports.py
@@ -1,4 +1,5 @@
 import logging
+from autologging import logged
 
 from lxml import etree
 
@@ -7,6 +8,8 @@ from ckanext.spatial.lib.report import ReportTable
 from ckan import model
 from ckanext.harvest.model import HarvestObject
 
+
+@logged
 def validation_report(package_id=None):
     '''
     Looks at every harvested metadata record and compares the

--- a/ckanext/spatial/model/harvested_metadata.py
+++ b/ckanext/spatial/model/harvested_metadata.py
@@ -1,6 +1,7 @@
 from lxml import etree
 
 import logging
+from autologging import traced
 log = logging.getLogger(__name__)
 
 
@@ -8,6 +9,7 @@ class MappedXmlObject(object):
     elements = []
 
 
+@traced
 class MappedXmlDocument(MappedXmlObject):
     def __init__(self, xml_str=None, xml_tree=None):
         assert (xml_str or xml_tree is not None), 'Must provide some XML in one format or another'
@@ -48,6 +50,7 @@ class MappedXmlDocument(MappedXmlObject):
         pass
 
 
+@traced
 class MappedXmlElement(MappedXmlObject):
     namespaces = {}
 
@@ -432,6 +435,7 @@ class ISOUsage(ISOElement):
    ]
 
 
+@traced
 class ISOAggregationInfo(ISOElement):
 
     elements = [

--- a/ckanext/spatial/model/harvested_metadata.py
+++ b/ckanext/spatial/model/harvested_metadata.py
@@ -9,7 +9,6 @@ class MappedXmlObject(object):
     elements = []
 
 
-@traced
 class MappedXmlDocument(MappedXmlObject):
     def __init__(self, xml_str=None, xml_tree=None):
         assert (xml_str or xml_tree is not None), 'Must provide some XML in one format or another'
@@ -50,7 +49,6 @@ class MappedXmlDocument(MappedXmlObject):
         pass
 
 
-@traced
 class MappedXmlElement(MappedXmlObject):
     namespaces = {}
 
@@ -435,7 +433,6 @@ class ISOUsage(ISOElement):
    ]
 
 
-@traced
 class ISOAggregationInfo(ISOElement):
 
     elements = [

--- a/ckanext/spatial/model/package_extent.py
+++ b/ckanext/spatial/model/package_extent.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from autologging import logged, traced
 
 from sqlalchemy import Table
 
@@ -16,6 +17,7 @@ package_extent_table = None
 
 DEFAULT_SRID = 4326 #(WGS 84)
 
+@logged
 def setup(srid=None):
 
     if package_extent_table is None:
@@ -51,6 +53,7 @@ def setup(srid=None):
         log.debug('Spatial tables creation deferred')
 
 
+@traced
 class PackageExtent(DomainObject):
     def __init__(self, package_id=None, the_geom=None):
         self.package_id = package_id

--- a/ckanext/spatial/plugin.py
+++ b/ckanext/spatial/plugin.py
@@ -2,6 +2,7 @@ import os
 import re
 import mimetypes
 from logging import getLogger
+from autologging import traced
 
 from pylons import config
 
@@ -59,6 +60,8 @@ def package_error_summary(error_dict):
             summary[p.toolkit._(prettify(key))] = error[0]
     return summary
 
+
+@traced
 class SpatialMetadata(p.SingletonPlugin):
 
     p.implements(p.IPackageController, inherit=True)
@@ -150,6 +153,7 @@ class SpatialMetadata(p.SingletonPlugin):
                 'get_common_map_config' : spatial_helpers.get_common_map_config,
                 }
 
+@traced
 class SpatialQuery(p.SingletonPlugin):
 
     p.implements(p.IRoutes, inherit=True)
@@ -390,6 +394,8 @@ class SpatialQuery(p.SingletonPlugin):
             search_results['results'] = pkgs
         return search_results
 
+
+@traced
 class HarvestMetadataApi(p.SingletonPlugin):
     '''
     Harvest Metadata API

--- a/ckanext/spatial/validation/validation.py
+++ b/ckanext/spatial/validation/validation.py
@@ -1,6 +1,7 @@
 import os
 import requests
 
+from autologging import logged, TRACE, traced
 from pkg_resources import resource_stream
 from ckanext.spatial.model import ISODocument
 
@@ -68,6 +69,7 @@ class XsdValidator(BaseValidator):
         return True, []
 
 
+@traced
 class ISO19139Schema(XsdValidator):
     name = 'iso19139'
     title = 'ISO19139 XSD Schema'
@@ -86,6 +88,7 @@ class ISO19139Schema(XsdValidator):
         return is_valid, errors
 
 
+@traced
 class ISO19139EdenSchema(XsdValidator):
     name = 'iso19139eden'
     title = 'ISO19139 XSD Schema (EDEN 2009-03-16)'
@@ -142,6 +145,7 @@ class ISO19139EdenSchema(XsdValidator):
             return 'dataset'
 
 
+@traced
 class ISO19139NGDCSchema(XsdValidator):
     '''
     XSD based validation for ISO 19139 documents.
@@ -163,6 +167,7 @@ class ISO19139NGDCSchema(XsdValidator):
         return cls._is_valid(xml, xsd_filepath, 'NGDC Schema (schema.xsd)')
 
 
+@traced
 class FGDCSchema(XsdValidator):
     '''
     XSD based validation for FGDC metadata documents.
@@ -273,6 +278,7 @@ class SchematronValidator(BaseValidator):
         return etree.XSLT(compiled)
 
 
+@traced
 class ConstraintsSchematron(SchematronValidator):
     name = 'constraints'
     title = 'ISO19139 Table A.1 Constraints Schematron (Medin 1.3)'
@@ -286,6 +292,7 @@ class ConstraintsSchematron(SchematronValidator):
             return [cls.schematron(schema)]
 
 
+@traced
 class ConstraintsSchematron14(SchematronValidator):
     name = 'constraints-1.4'
     title = 'ISO19139 Table A.1 Constraints Schematron (Medin/Parslow 1.4)'
@@ -298,6 +305,7 @@ class ConstraintsSchematron14(SchematronValidator):
             return [cls.schematron(schema)]
 
 
+@traced
 class Gemini2Schematron(SchematronValidator):
     name = 'gemini2'
     title = 'GEMINI 2.1 Schematron 1.2'
@@ -310,6 +318,7 @@ class Gemini2Schematron(SchematronValidator):
             return [cls.schematron(schema)]
 
 
+@traced
 class Gemini2Schematron13(SchematronValidator):
     name = 'gemini2-1.3'
     title = 'GEMINI 2.1 Schematron 1.3'
@@ -321,6 +330,7 @@ class Gemini2Schematron13(SchematronValidator):
             return [cls.schematron(schema)]
 
 
+@traced
 class Gemini2Schematron3(SchematronValidator):
     name = 'gemini2-3'
     title = 'GEMINI 2.3 Schematron 1.0'
@@ -404,6 +414,7 @@ if __name__ == '__main__':
     pprint(result)
 
 
+@traced
 class SchDocumentResolver(etree.Resolver):
     def resolve(self, url, id, context):
         log.debug("Resolving URL '%s'" % url)

--- a/ckanext/spatial/validation/validation.py
+++ b/ckanext/spatial/validation/validation.py
@@ -191,6 +191,7 @@ class FGDCSchema(XsdValidator):
             xml, xsd_filepath, 'FGDC Schema (fgdc-std-001-1998.xsd)')
 
 
+@traced
 class SchematronValidator(BaseValidator):
     '''Base class for a validator that uses Schematron.'''
     has_init = False
@@ -353,6 +354,7 @@ all_validators = (ISO19139Schema,
                   Gemini2Schematron3)
 
 
+@traced
 class Validators(object):
     '''
     Validates XML against one or more profiles (i.e. validators).

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,3 +14,5 @@ pyproj==1.9.3
 requests>=2.0
 Shapely>=1.2.13
 urllib3==1.23
+
+-e git+https://github.com/alphagov/Autologging.git@only_trace_calls#egg=AutoLogging


### PR DESCRIPTION
## What

Add additional logging to help identify tests from code paths used on production, it is using a forked repo which has been adapted to minimise the number of additional logs.

https://github.com/alphagov/Autologging/tree/only_trace_calls

This will be left in place for a week or more to help identify tests to convert and the commit should be dropped after the tests have been identified.

## Reference 

https://trello.com/c/ayNNNyB2/2329-add-logging-to-trace-calls-in-ckanext-spatial

