### PR TITLE
Set the source config for gemini-csw harvest

### DIFF
--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -588,6 +588,8 @@ class GeminiCswHarvester(GeminiHarvester, SingletonPlugin):
         # Get source URL
         url = harvest_job.source.url
 
+        self._set_source_config(harvest_job.source.config)
+
         try:
             self._setup_csw_client(url)
         except Exception as e:


### PR DESCRIPTION
If we don't do this it will automatically be set to the profile set in the config, which will override any publisher settings.