### PR TITLE
Pin sqlalchemy to 1.4.52 as CKAN 2.10.4 hasn't updated orm import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ cryptography==38.0.4
 pyopenssl==22.1.0
 
 GeoAlchemy2==0.15.01
+sqlalchemy==1.4.52


### PR DESCRIPTION
Need to pin sqlalchemy as latest versions are not compatible with CKAN 2.10