### PR TITLE
Push metrics from pycsw_load

### DIFF
--- a/bin/ckan_pycsw.py
+++ b/bin/ckan_pycsw.py
@@ -222,11 +222,6 @@ def _update_records(changed, gathered_records, ckan_url, repo, context, error_co
 
 
 def load(pycsw_config, ckan_url):
-
-    if sys.version_info < (3, 0):
-        log.info("Python 2 detected: Please upgrade to CKAN 2.9 and python 3")
-        return
-
     database = pycsw_config.get('repository', 'database')
     table_name = pycsw_config.get('repository', 'table')
 
@@ -266,11 +261,6 @@ def load(pycsw_config, ckan_url):
 
 
 def clear(pycsw_config):
-
-    if sys.version_info < (3, 0):
-        log.info("Python 2 detected:  Please upgrade to CKAN 2.9 and python 3")
-        return
-
     from sqlalchemy import create_engine, MetaData, Table
 
     database = pycsw_config.get("repository", "database")

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ pyopenssl==22.1.0
 
 GeoAlchemy2==0.15.01
 sqlalchemy==1.4.52
+
+prometheus-client==0.20


### PR DESCRIPTION
Push pycsw load metrics for last successful job run so that any problems in running the load can be detected early.