### PR TITLE
Update crypto lib for CVE-2023-50782 fix.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ Shapely==2.0.4
 OWSLib==0.28.1
 geojson==3.0.1
 
-cryptography==38.0.4
-pyopenssl==22.1.0
+cryptography==42.0.8
+pyopenssl==24.1.0
 
 GeoAlchemy2==0.15.01
 sqlalchemy==1.4.52


### PR DESCRIPTION
Should resolve https://github.com/alphagov/ckanext-spatial/security/dependabot/18.

Dependabot fails with `dependency_file_not_found` on this for some reason, perhaps because of the fork situation.

Lemme know if I should do something else with the branches instead, not sure what the arrangement is with this fork.