### PR TITLE
Don't run duplicate CodeQL jobs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Tests
-on: [push, pull_request]
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   codeql-sast:


### PR DESCRIPTION
These are somewhat slow jobs. We don't want to duplicate them unnecessarily.

Also specify `workflow_dispatch` so that we can test the workflow via the GitHub UI.