### PR TITLE
Update check for metadata-date format

### DIFF
--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -124,13 +124,10 @@ class GeminiHarvester(SpatialHarvester):
 
         # Save the metadata reference date in the Harvest Object
         try:
-            metadata_modified_date = datetime.strptime(gemini_values['metadata-date'],'%Y-%m-%d')
+            metadata_modified_date = datetime.fromisoformat(gemini_values['metadata-date'])
         except ValueError:
-            try:
-                metadata_modified_date = datetime.strptime(gemini_values['metadata-date'],'%Y-%m-%dT%H:%M:%S')
-            except:
-                raise Exception('Could not extract reference date for GUID %s (%s)' \
-                        % (gemini_guid,gemini_values['metadata-date']))
+            raise Exception('Could not extract reference date for GUID %s (%s)' \
+                    % (gemini_guid,gemini_values['metadata-date']))
 
         self.obj.metadata_modified_date = metadata_modified_date
         self.obj.save()

--- a/ckanext/spatial/tests/test_harvest.py
+++ b/ckanext/spatial/tests/test_harvest.py
@@ -820,7 +820,7 @@ class TestHarvest(HarvestFixtureBase):
             'source_type': u'gemini-single',
             'owner_org': 'test-org',
             'metadata_created': datetime.now().strftime('%YYYY-%MM-%DD %HH:%MM:%s'),
-            'metadata_modified': datetime.now().strftime('%YYYY-%MM-%DD %HH:%MM:%s'),
+            'metadata_modified': datetime.now().strftime('%YYYY-%MM-%DD %HH:%MM:%s.%f'),
 
         }
 


### PR DESCRIPTION
The current implementation doesn't take into account milliseconds, this fix should handle ISO 8601 date time formats.