### PR TITLE
Add user-agent header to the schema resolver to prevent 403 responses

### DIFF
--- a/ckanext/spatial/validation/validation.py
+++ b/ckanext/spatial/validation/validation.py
@@ -409,6 +409,6 @@ if __name__ == '__main__':
 class SchDocumentResolver(etree.Resolver):
     def resolve(self, url, id, context):
         log.debug("Resolving URL '%s'" % url)
-        response = requests.get(url)
+        response = requests.get(url, headers={"User-Agent": "data.gov.uk"})
         res = self.resolve_string(response.text, context)
         return res


### PR DESCRIPTION
The responses were being parsed as the xml response during a harvest causing incorrect validation results. 

Adding the user-agent header makes it less likely for the request to be rejected and the server responding with a 403.

This probably explains why some publishers were experiencing intermittent validation failures during harvesting.